### PR TITLE
prevent $stateChangeStart Events. Updated Tests accordingly

### DIFF
--- a/src/permission.mdl.js
+++ b/src/permission.mdl.js
@@ -24,26 +24,31 @@
           event.preventDefault();
 
           Permission.authorize(permissions, toParams).then(function () {
-            $rootScope.$broadcast('$stateChangePermissionAccepted');
-
             // If authorized, use call state.go without triggering the event.
             // Then trigger $stateChangeSuccess manually to resume the rest of the process
             // Note: This is a pseudo-hacky fix which should be fixed in future ui-router versions
-            $state.go(toState.name, toParams, {notify: false}).then(function() {
-              $rootScope
-                .$broadcast('$stateChangeSuccess', toState, toParams, fromState, fromParams);
-            });
+            
+            if (!$rootScope.$broadcast('$stateChangeStart', toState.name, toParams, fromState.name, fromParams).defaultPrevented) {
+              $rootScope.$broadcast('$stateChangePermissionAccepted');
 
-          }, function () {
-            $rootScope.$broadcast('$stateChangePermissionDenied');
-
-            // If not authorized, redirect to wherever the route has defined, if defined at all
-            var redirectTo = permissions.redirectTo;
-            if (redirectTo) {
-              $state.go(redirectTo, {}, {notify: false}).then(function() {
+              $state.go(toState.name, toParams, {notify: false}).then(function() {
                 $rootScope
                   .$broadcast('$stateChangeSuccess', toState, toParams, fromState, fromParams);
               });
+            }
+
+          }, function () {
+            if (!$rootScope.$broadcast('$stateChangeStart', toState.name, toParams, fromState.name, fromParams).defaultPrevented) {
+              $rootScope.$broadcast('$stateChangePermissionDenied');
+
+              // If not authorized, redirect to wherever the route has defined, if defined at all
+              var redirectTo = permissions.redirectTo;
+              if (redirectTo) {
+                $state.go(redirectTo, {}, {notify: false}).then(function() {
+                  $rootScope
+                    .$broadcast('$stateChangeSuccess', toState, toParams, fromState, fromParams);
+                });
+              }
             }
           });
         }

--- a/src/permission.mdl.test.js
+++ b/src/permission.mdl.test.js
@@ -101,58 +101,149 @@ describe('Module: Permission', function () {
     it('should go to an accepted state', inject (function($rootScope) {
       initStateTo('home');
       $state.go('accepted');
-      spyOn($rootScope, '$broadcast');
+
+      var changePermissionAcceptedHasBeenCalled = false;
+      $rootScope.$on('$stateChangePermissionAccepted', function () {
+        changePermissionAcceptedHasBeenCalled = true;
+      });
+
+      var changePermissionDeniedHasBeenCalled = false;
+      $rootScope.$on('$stateChangePermissionDenied', function () {
+        changePermissionDeniedHasBeenCalled = true;
+      });
+
 
       $rootScope.$digest();
       expect($state.current.name).toBe('accepted');
-      expect($rootScope.$broadcast).toHaveBeenCalledWith('$stateChangePermissionAccepted');
-      expect($rootScope.$broadcast).not.toHaveBeenCalledWith('$stateChangePermissionDenied');
+      expect(changePermissionAcceptedHasBeenCalled).toBeTruthy();
+      expect(changePermissionDeniedHasBeenCalled).not.toBeTruthy();
     }));
 
     it('should not go to the denied state', function () {
       initStateTo('home');
       $state.go('denied');
-      spyOn($rootScope, '$broadcast');
+      var changePermissionAcceptedHasBeenCalled = false;
+      $rootScope.$on('$stateChangePermissionAccepted', function () {
+        changePermissionAcceptedHasBeenCalled = true;
+      });
 
+      var changePermissionDeniedHasBeenCalled = false;
+      $rootScope.$on('$stateChangePermissionDenied', function () {
+        changePermissionDeniedHasBeenCalled = true;
+      });
 
       $rootScope.$digest();
       expect($state.current.name).toBe('home');
-      expect($rootScope.$broadcast).not.toHaveBeenCalledWith('$stateChangePermissionAccepted');
-      expect($rootScope.$broadcast).toHaveBeenCalledWith('$stateChangePermissionDenied');
+      expect(changePermissionAcceptedHasBeenCalled).not.toBeTruthy();
+      expect(changePermissionDeniedHasBeenCalled).toBeTruthy();
     });
 
     it('should not go to the denied state but redirect to the provided state', function () {
       initStateTo('home');
       $state.go('deniedWithRedirect');
-      spyOn($rootScope, '$broadcast');
+      var changePermissionAcceptedHasBeenCalled = false;
+      $rootScope.$on('$stateChangePermissionAccepted', function () {
+        changePermissionAcceptedHasBeenCalled = true;
+      });
 
+      var changePermissionDeniedHasBeenCalled = false;
+      $rootScope.$on('$stateChangePermissionDenied', function () {
+        changePermissionDeniedHasBeenCalled = true;
+      });
       $rootScope.$digest();
       expect($state.current.name).toBe('redirectToThisState');
-      expect($rootScope.$broadcast).not.toHaveBeenCalledWith('$stateChangePermissionAccepted');
-      expect($rootScope.$broadcast).toHaveBeenCalledWith('$stateChangePermissionDenied');
+      expect(changePermissionAcceptedHasBeenCalled).not.toBeTruthy();
+      expect(changePermissionDeniedHasBeenCalled).toBeTruthy();
     });
 
     it('should pass state params (only)', function () {
       initStateTo('home');
       $state.go('onlyWithParams',{isset: true});
-      spyOn($rootScope, '$broadcast').andCallThrough();
+      var changePermissionAcceptedHasBeenCalled = false;
+      $rootScope.$on('$stateChangePermissionAccepted', function () {
+        changePermissionAcceptedHasBeenCalled = true;
+      });
+
+      var changePermissionDeniedHasBeenCalled = false;
+      $rootScope.$on('$stateChangePermissionDenied', function () {
+        changePermissionDeniedHasBeenCalled = true;
+      });
 
       $rootScope.$digest();
       expect($state.current.name).toBe('onlyWithParams');
-      expect($rootScope.$broadcast).toHaveBeenCalledWith('$stateChangePermissionAccepted');
-      expect($rootScope.$broadcast).not.toHaveBeenCalledWith('$stateChangePermissionDenied');
+      expect(changePermissionAcceptedHasBeenCalled).toBeTruthy();
+      expect(changePermissionDeniedHasBeenCalled).not.toBeTruthy();
     });
 
     it('should pass state params (except)', function () {
       initStateTo('home');
       $state.go('exceptWithParams',{isset: true});
-      spyOn($rootScope, '$broadcast').andCallThrough();
+      var changePermissionAcceptedHasBeenCalled = false;
+      $rootScope.$on('$stateChangePermissionAccepted', function () {
+        changePermissionAcceptedHasBeenCalled = true;
+      });
+
+      var changePermissionDeniedHasBeenCalled = false;
+      $rootScope.$on('$stateChangePermissionDenied', function () {
+        changePermissionDeniedHasBeenCalled = true;
+      });
 
       $rootScope.$digest();
       expect($state.current.name).toBe('home');
-      expect($rootScope.$broadcast).not.toHaveBeenCalledWith('$stateChangePermissionAccepted');
-      expect($rootScope.$broadcast).toHaveBeenCalledWith('$stateChangePermissionDenied');
+      expect(changePermissionAcceptedHasBeenCalled).not.toBeTruthy();
+      expect(changePermissionDeniedHasBeenCalled).toBeTruthy();
     });
+
+    it('should not go to a accepted state when $stateChangeStart has been cancelled', function () {
+      initStateTo('home');
+      
+      $rootScope.$on('$stateChangeStart', function (event) {
+        event.preventDefault();
+      });
+
+      $state.go('accepted');
+      var changePermissionAcceptedHasBeenCalled = false;
+      $rootScope.$on('$stateChangePermissionAccepted', function () {
+        changePermissionAcceptedHasBeenCalled = true;
+      });
+
+      var changePermissionDeniedHasBeenCalled = false;
+      $rootScope.$on('$stateChangePermissionDenied', function () {
+        changePermissionDeniedHasBeenCalled = true;
+      });
+
+      $rootScope.$digest();
+      expect($state.current.name).toBe('home');
+      // neither of them should have been called because the event was aborted manually
+      expect(changePermissionAcceptedHasBeenCalled).not.toBeTruthy();
+      expect(changePermissionDeniedHasBeenCalled).not.toBeTruthy();
+    });
+
+    it('should not go to a denied state when $stateChangeStart has been cancelled', function () {
+      initStateTo('home');
+      
+      $rootScope.$on('$stateChangeStart', function (event) {
+        event.preventDefault();
+      });
+
+      $state.go('denied');
+      var changePermissionAcceptedHasBeenCalled = false;
+      $rootScope.$on('$stateChangePermissionAccepted', function () {
+        changePermissionAcceptedHasBeenCalled = true;
+      });
+
+      var changePermissionDeniedHasBeenCalled = false;
+      $rootScope.$on('$stateChangePermissionDenied', function () {
+        changePermissionDeniedHasBeenCalled = true;
+      });
+
+      $rootScope.$digest();
+      expect($state.current.name).toBe('home');
+      // neither of them should have been called because the event was aborted manually
+      expect(changePermissionAcceptedHasBeenCalled).not.toBeTruthy();
+      expect(changePermissionDeniedHasBeenCalled).not.toBeTruthy();
+    });
+
 
   });
 


### PR DESCRIPTION
This is the pull request for my issue narzerus/angular-permission#9 

I used the same check that ui-router is using in their [$stateProvider](https://github.com/angular-ui/ui-router/blob/master/src/state.js#L846)

Also I updated the tests to not spyOn $broadcast. It's not wise to spy on $broadcast when using ui-router. This is the approach that the ui-router team is using themselves in their tests.

The tests for the event prevention can be found at the bottom.

_This time I used the correct jshint settings ;)_

_Edit_: selected the correct lines in the ui-router $stateProvider
