### PR TITLE
Check all

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 node_modules
 .tmp
 bower_components

--- a/demo/DemoApp.js
+++ b/demo/DemoApp.js
@@ -1,0 +1,92 @@
+'use strict';
+
+angular.module('demoApp', ['ui.router', 'permission']);
+
+angular.module('demoApp').controller('MessageInterceptorController', function ($scope) {
+	var self = this;
+
+	$scope.$on('$stateChangePermissionAccepted', function (event, toState, toParams, fromState, fromParams, role, reason) {
+		console.log('accepted', arguments);
+		self.status = 'accepted'; 
+		self.message = {
+			toState: toState,
+			toParams: toParams,
+			fromState: fromState,
+			fromParams: fromParams,
+			role: role,
+			reason: reason
+		};
+	});
+
+	$scope.$on('$stateChangePermissionDenied', function (event, toState, toParams, fromState, fromParams, role, reason) {
+		console.log('denied', arguments);
+		self.status = 'denied'; 
+		self.message = {
+			toState: toState,
+			toParams: toParams,
+			fromState: fromState,
+			fromParams: fromParams,
+			role: role,
+			reason: reason
+		};
+	});
+
+});
+
+angular.module('demoApp').config(function ($stateProvider, $urlRouterProvider) {
+
+	$stateProvider.state('home', {
+		url: '/',
+		templateUrl: 'home.template.html'
+	});
+
+	$stateProvider.state('restricted', {
+		url: '/restricted',
+		template: '<h1>Restricted</h1>',
+		data: {
+			permissions: {
+				all: {
+					'roleA': {
+						redirectTo: 'stateA'
+					}, 
+					'roleB': {
+						redirectTo: 'stateB'
+					}
+				},
+				redirectTo: 'stateC'
+			}			
+		}
+	});
+
+	$stateProvider.state('stateA', {
+		url: '/stateA',
+		template: '<h1>State A</h1>'
+	});
+
+	$stateProvider.state('stateB', {
+		url: '/stateB',
+		template: '<h1>State B</h1>'
+	});
+
+	$stateProvider.state('stateC', {
+		url: '/stateC',
+		template: '<h1>State C</h1>'
+	});
+
+	$urlRouterProvider.otherwise('/');
+});
+
+angular.module('demoApp').run(function (Permission, $q) {
+
+  Permission.defineRole('roleA', function () {
+  	var deferred = $q.defer();
+  	deferred.resolve('Hello World');
+    return deferred.promise;
+  });
+
+  Permission.defineRole('roleB', function () {
+  	var deferred = $q.defer();
+  	deferred.reject('Hello Test');
+  	return deferred.promise;
+  });
+});

--- a/demo/home.template.html
+++ b/demo/home.template.html
@@ -1,0 +1,4 @@
+<div>
+	<h1>Home</h1>
+	<button ui-sref="restricted">go to restricted state</button>
+</div>

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html class="no-js">
+  <head>
+    <meta charset="utf-8">
+    <title></title>
+    <meta name="description" content="">
+    <meta name="viewport" content="width=device-width">
+  </head>
+  <body ng-app="demoApp">
+    
+    <div ng-controller="MessageInterceptorController as messageInterceptor">
+      <h1>{{::messageInterceptor.status}}</h1>
+      <pre>{{::messageInterceptor.message | json}}</pre>
+    </div>
+
+    <hr>
+
+    <div ui-view></div>
+
+
+    <script src="../bower_components/angular/angular.js"></script>
+    <script src="../bower_components/angular-ui-router/release/angular-ui-router.js"></script>
+    <script src="../src/permission.mdl.js"></script>
+    <script src="../src/permission.svc.js"></script>
+
+    <script src="DemoApp.js"></script>    <!-- endbuild -->
+</body>
+</html>

--- a/dist/angular-permission.js
+++ b/dist/angular-permission.js
@@ -51,7 +51,7 @@
               $rootScope.$broadcast('$stateChangePermissionDenied');
 
               rejection = rejection || {};
-              $rootScope.$broadcast('$stateChangePermissionDenied', toState.name, toParams, fromState.name, fromParams, rejection.role, rejection.reason);
+              $rootScope.$broadcast('$stateChangePermissionDenied', toState.name, toParams, fromState.name, fromParams, rejection.role, rejection.response);
 
               var redirectTo;
               if(rejection && rejection.redirectTo) {
@@ -215,13 +215,13 @@
                     deferred.resolve();
                   }
                 },
-                function rejected (reason) {
+                function rejected (response) {
                   // if the roles were provided in an object
                   if(angular.isObject(roles) && roles[role.name] && roles[role.name].redirectTo) {
-                    deferred.reject({role: role.name, reason: reason, redirectTo: roles[role.name].redirectTo});
+                    deferred.reject({role: role.name, response: response, redirectTo: roles[role.name].redirectTo});
                   }
                   else {
-                    deferred.reject({role: role.name, reason: reason});
+                    deferred.reject({role: role.name, response: response});
                   }
                 }
               );

--- a/src/permission.mdl.js
+++ b/src/permission.mdl.js
@@ -35,12 +35,23 @@
                   .$broadcast('$stateChangeSuccess', toState, toParams, fromState, fromParams);
               });
             }
-          }, function () {
-            if (!$rootScope.$broadcast('$stateChangeStart', toState.name, toParams, fromState.name, fromParams).defaultPrevented) {
-              $rootScope.$broadcast('$stateChangePermissionDenied', toState, toParams);
 
-              // If not authorized, redirect to wherever the route has defined, if defined at all
-              var redirectTo = permissions.redirectTo;
+          }, function (rejection) {
+            if (!$rootScope.$broadcast('$stateChangeStart', toState.name, toParams, fromState.name, fromParams).defaultPrevented) {
+              $rootScope.$broadcast('$stateChangePermissionDenied');
+
+              rejection = rejection || {};
+              $rootScope.$broadcast('$stateChangePermissionDenied', toState.name, toParams, fromState.name, fromParams, rejection.role, rejection.reason);
+
+              var redirectTo;
+              if(rejection && rejection.redirectTo) {
+                redirectTo = rejection.redirectTo;
+              } 
+              else {                
+                // If not authorized, redirect to wherever the route has defined, if defined at all
+                redirectTo = permissions.redirectTo;
+              }
+
               if (redirectTo) {
                 $state.go(redirectTo, {}, {notify: false}).then(function() {
                   $rootScope

--- a/src/permission.mdl.js
+++ b/src/permission.mdl.js
@@ -39,8 +39,6 @@
 
           }, function (rejection) {
             if (!$rootScope.$broadcast('$stateChangeStart', toState.name, toParams, fromState.name, fromParams).defaultPrevented) {
-              $rootScope.$broadcast('$stateChangePermissionDenied');
-
               rejection = rejection || {};
               $rootScope.$broadcast('$stateChangePermissionDenied', toState.name, toParams, fromState.name, fromParams, rejection.role, rejection.response);
 

--- a/src/permission.mdl.js
+++ b/src/permission.mdl.js
@@ -24,11 +24,12 @@
           event.preventDefault();
 
           Permission.authorize(permissions, toParams).then(function () {
+
             // If authorized, use call state.go without triggering the event.
             // Then trigger $stateChangeSuccess manually to resume the rest of the process
             // Note: This is a pseudo-hacky fix which should be fixed in future ui-router versions
             if (!$rootScope.$broadcast('$stateChangeStart', toState.name, toParams, fromState.name, fromParams).defaultPrevented) {
-              $rootScope.$broadcast('$stateChangePermissionAccepted', toState, toParams);
+              $rootScope.$broadcast('$stateChangePermissionAccepted');
 
               $state.go(toState.name, toParams, {notify: false}).then(function() {
                 $rootScope

--- a/src/permission.mdl.js
+++ b/src/permission.mdl.js
@@ -23,23 +23,25 @@
         if (permissions) {
           event.preventDefault();
 
-          Permission.authorize(permissions, toParams).then(function () {
+          Permission.authorize(permissions, toParams).then(function (resolution) {
+            resolution = resolution || {};
 
             // If authorized, use call state.go without triggering the event.
             // Then trigger $stateChangeSuccess manually to resume the rest of the process
             // Note: This is a pseudo-hacky fix which should be fixed in future ui-router versions
             if (!$rootScope.$broadcast('$stateChangeStart', toState.name, toParams, fromState.name, fromParams).defaultPrevented) {
-              $rootScope.$broadcast('$stateChangePermissionAccepted');
+              $rootScope.$broadcast('$stateChangePermissionAccepted', toState, toParams, fromState, fromParams, resolution.role, resolution.reason);
 
               $state.go(toState.name, toParams, {notify: false}).then(function() {
-                $rootScope
-                  .$broadcast('$stateChangeSuccess', toState, toParams, fromState, fromParams);
+                $rootScope.$broadcast('$stateChangeSuccess', toState, toParams, fromState, fromParams);
               });
             }
 
           }, function (rejection) {
             if (!$rootScope.$broadcast('$stateChangeStart', toState.name, toParams, fromState.name, fromParams).defaultPrevented) {
-              $rootScope.$broadcast('$stateChangePermissionDenied');
+              
+              rejection = rejection || {};
+              $rootScope.$broadcast('$stateChangePermissionDenied', toState.name, toParams, fromState.name, fromParams, rejection.role, rejection.reason);
 
               rejection = rejection || {};
               $rootScope.$broadcast('$stateChangePermissionDenied', toState.name, toParams, fromState.name, fromParams, rejection.role, rejection.reason);
@@ -55,8 +57,7 @@
 
               if (redirectTo) {
                 $state.go(redirectTo, {}, {notify: false}).then(function() {
-                  $rootScope
-                    .$broadcast('$stateChangeSuccess', toState, toParams, fromState, fromParams);
+                  $rootScope.$broadcast('$stateChangeSuccess', toState, toParams, fromState, fromParams);
                 });
               }
             }

--- a/src/permission.mdl.js
+++ b/src/permission.mdl.js
@@ -42,7 +42,7 @@
               $rootScope.$broadcast('$stateChangePermissionDenied');
 
               rejection = rejection || {};
-              $rootScope.$broadcast('$stateChangePermissionDenied', toState.name, toParams, fromState.name, fromParams, rejection.role, rejection.reason);
+              $rootScope.$broadcast('$stateChangePermissionDenied', toState.name, toParams, fromState.name, fromParams, rejection.role, rejection.response);
 
               var redirectTo;
               if(rejection && rejection.redirectTo) {

--- a/src/permission.mdl.test.js
+++ b/src/permission.mdl.test.js
@@ -327,26 +327,6 @@ describe('Module: Permission', function () {
       expect($state.current.name).toBe('redirectToThisState');
     });
 
-
-    it('should not resolve if one role rejects but go to the redirectTo state if provided by the rejecting role and favor this redirection over the one in the state', function () {
-      $stateProvider.state('denyCheckAllWithArrayAndRedirectInRejection', {
-        data: {
-          permissions: {
-            all: ['accepted', 'reject-with-redirect'],
-            redirectTo: 'redirectToThisState'
-          }
-        }
-      });
-
-      initStateTo('home');
-      $state.go('denyCheckAllWithArrayAndRedirectInRejection');
-
-      $rootScope.$digest();
-
-      expect($state.current.name).toBe('redirectToAnotherState');
-    });
-
-
     it('should not resolve if one role rejects but go to the redirectTo state provided in the configured state although a reason was provided with the rejection', function () {
       $stateProvider.state('denyCheckAllWithArrayAndNoRedirectInRejection', {
         data: {

--- a/src/permission.mdl.test.js
+++ b/src/permission.mdl.test.js
@@ -48,9 +48,36 @@ describe('Module: Permission', function () {
       return params.isset === true;
     });
 
+    // for check all
+    PermissionProvider.defineRole('resolve', function () {
+      var deferred = $q.defer();
+      deferred.resolve();
+      return deferred.promise;
+    });
+
+    PermissionProvider.defineRole('reject', function () {
+      var deferred = $q.defer();
+      deferred.reject();
+      return deferred.promise;
+    });
+
+    PermissionProvider.defineRole('reject-with-redirect', function () {
+      var deferred = $q.defer();
+      deferred.reject({redirectTo: 'redirectToAnotherState'});
+      return deferred.promise;
+    });
+
+    PermissionProvider.defineRole('reject-with-reason', function () {
+      var deferred = $q.defer();
+      deferred.reject({reason: 'just cause'});
+      return deferred.promise;
+    }); 
+
+
 
     $stateProvider.state('home', {});
     $stateProvider.state('redirectToThisState', {});
+    $stateProvider.state('redirectToAnotherState', {});
 
 
     $stateProvider.state('accepted', {
@@ -94,7 +121,8 @@ describe('Module: Permission', function () {
           except: ['withParams']
         }
       }
-    });
+    });  
+
   });
 
   describe('On $stateChangeStart', function () {
@@ -244,7 +272,233 @@ describe('Module: Permission', function () {
       expect(changePermissionDeniedHasBeenCalled).not.toBeTruthy();
     });
 
+  });
 
+  describe('Permissions: check all with array', function () {
+    it('should resolve if all roles are true or resolved', function () {
+      $stateProvider.state('acceptCheckAllWithArray', {
+        data: {
+          permissions: {
+            all: ['accepted', 'resolve']
+          }
+        }
+      });
+
+      initStateTo('home');
+      $state.go('acceptCheckAllWithArray');
+
+      $rootScope.$digest();
+
+      expect($state.current.name).toBe('acceptCheckAllWithArray');
+    });
+
+    it('should not resolve if one role rejects', function () {
+      $stateProvider.state('denyCheckAllWithArray', {
+        data: {
+          permissions: {
+            all: ['accepted', 'reject']
+          }
+        }
+      });
+
+      initStateTo('home');
+      $state.go('denyCheckAllWithArray');
+
+      $rootScope.$digest();
+
+      expect($state.current.name).toBe('home');
+    });
+
+    it('should not resolve if one role rejects but go to the redirectTo state if provided by the redirecTo property', function () {
+      $stateProvider.state('denyCheckAllWithArrayAndRedirect', {
+        data: {
+          permissions: {
+            all: ['accepted', 'reject'],
+            redirectTo: 'redirectToThisState'
+          }
+        }
+      });
+
+      initStateTo('home');
+      $state.go('denyCheckAllWithArrayAndRedirect');
+
+      $rootScope.$digest();
+
+      expect($state.current.name).toBe('redirectToThisState');
+    });
+
+
+    it('should not resolve if one role rejects but go to the redirectTo state if provided by the rejecting role and favor this redirection over the one in the state', function () {
+      $stateProvider.state('denyCheckAllWithArrayAndRedirectInRejection', {
+        data: {
+          permissions: {
+            all: ['accepted', 'reject-with-redirect'],
+            redirectTo: 'redirectToThisState'
+          }
+        }
+      });
+
+      initStateTo('home');
+      $state.go('denyCheckAllWithArrayAndRedirectInRejection');
+
+      $rootScope.$digest();
+
+      expect($state.current.name).toBe('redirectToAnotherState');
+    });
+
+
+    it('should not resolve if one role rejects but go to the redirectTo state provided in the configured state although a reason was provided with the rejection', function () {
+      $stateProvider.state('denyCheckAllWithArrayAndNoRedirectInRejection', {
+        data: {
+          permissions: {
+            all: ['accepted', 'reject-with-reason'],
+            redirectTo: 'redirectToThisState'
+          }
+        }
+      });
+
+      initStateTo('home');
+      $state.go('denyCheckAllWithArrayAndNoRedirectInRejection');
+
+      $rootScope.$digest();
+
+      expect($state.current.name).toBe('redirectToThisState');
+    });
+  });
+
+  describe('Permissions: check all with object', function () {
+    it('should resolve if all roles are true or resolved', function () {
+      $stateProvider.state('acceptCheckAllWithObject', {
+        data: {
+          permissions: {
+            all: {
+              accepted: {},
+              resolve: {}
+            }
+          }
+        }
+      });
+
+      initStateTo('home');
+      $state.go('acceptCheckAllWithObject');
+
+      $rootScope.$digest();
+
+      expect($state.current.name).toBe('acceptCheckAllWithObject');
+    });
+  
+    it('should reject if one of the roles is false or rejects', function () {
+      $stateProvider.state('denyCheckAllWithObject', {
+        data: {
+          permissions: {
+            all: {
+              accepted: {},
+              reject: {}
+            }
+          }
+        }
+      });
+
+      initStateTo('home');
+      $state.go('denyCheckAllWithObject');
+
+      $rootScope.$digest();
+
+      expect($state.current.name).toBe('home');
+    });
+
+    it('should reject if one of the roles is false or rejects and redirect to the redirectTo state', function () {
+      $stateProvider.state('denyCheckAllWithObjectButRedirect', {
+        data: {
+          permissions: {
+            all: {
+              accepted: {},
+              reject: {}
+            },
+            redirectTo: 'redirectToThisState'
+          }
+        }
+      });       
+
+      initStateTo('home');
+      $state.go('denyCheckAllWithObjectButRedirect');
+
+      $rootScope.$digest();
+
+      expect($state.current.name).toBe('redirectToThisState');
+    });    
+
+    it('should reject if one of the roles is false or rejects and redirect to the redirectTo state from the role and favor it over the redirectTo from the state', function () {
+      $stateProvider.state('denyCheckAllWithObjectButRedirectInRole', {
+        data: {
+          permissions: {
+            all: {
+              accepted: {},
+              reject: {
+                redirectTo: 'redirectToAnotherState'
+              }
+            },
+            redirectTo: 'redirectToThisState'
+          }
+        }
+      });          
+
+      initStateTo('home');
+      $state.go('denyCheckAllWithObjectButRedirectInRole');
+
+      $rootScope.$digest();
+
+      expect($state.current.name).toBe('redirectToAnotherState');
+    });    
+
+
+    it('should reject if one of the roles is false or rejects and redirect to the redirectTo state from the roles rejection function and favor it over the redirectTo from the state and over the redirectTo setting from the role in the stateProvider config', function () {
+      $stateProvider.state('denyCheckAllWithObjectButRedirectInRolesRejectFunction', {
+        data: {
+          permissions: {
+            all: {
+              accepted: {},
+              'reject-with-redirect': {
+                redirectTo: 'redirectToAnotherState'
+              }
+            },
+            redirectTo: 'redirectToThisState'
+          }
+        }
+      });       
+
+      initStateTo('home');
+      $state.go('denyCheckAllWithObjectButRedirectInRolesRejectFunction');
+
+      $rootScope.$digest();
+
+      expect($state.current.name).toBe('redirectToAnotherState');
+    });    
+
+    it('should reject if one of the roles is false or rejects and redirect to the redirectTo state from the state\'s redirectTo although the rejection reason was not empty', function () {
+      $stateProvider.state('denyCheckAllWithObjectButRedirectAlthoughNonsenseInRejectFunction', {
+          data: {
+            permissions: {
+              all: {
+                accepted: {},
+                'reject-with-reason': {
+                  redirectTo: 'redirectToAnotherState'
+                }
+              },
+              redirectTo: 'redirectToThisState'
+            }
+          }
+      });  
+
+      initStateTo('home');
+      $state.go('denyCheckAllWithObjectButRedirectAlthoughNonsenseInRejectFunction');
+
+      $rootScope.$digest();
+
+      expect($state.current.name).toBe('redirectToAnotherState');
+    });    
+    
+  
   });
 
 });

--- a/src/permission.mdl.test.js
+++ b/src/permission.mdl.test.js
@@ -45,7 +45,7 @@ describe('Module: Permission', function () {
     });
 
     PermissionProvider.defineRole('withParams', function(params) {
-      return params.isset === true;
+      return params.isset === 'true';
     });
 
     // for check all

--- a/src/permission.svc.js
+++ b/src/permission.svc.js
@@ -139,13 +139,13 @@
                     deferred.resolve();
                   }
                 },
-                function rejected (reason) {
+                function rejected (response) {
                   // if the roles were provided in an object
                   if(angular.isObject(roles) && roles[role.name] && roles[role.name].redirectTo) {
-                    deferred.reject({role: role.name, reason: reason, redirectTo: roles[role.name].redirectTo});
+                    deferred.reject({role: role.name, response: response, redirectTo: roles[role.name].redirectTo});
                   }
                   else {
-                    deferred.reject({role: role.name, reason: reason});
+                    deferred.reject({role: role.name, response: response});
                   }
                 }
               );

--- a/src/permission.svc.test.js
+++ b/src/permission.svc.test.js
@@ -91,12 +91,6 @@ describe('Service: Permission', function () {
         return deferred.promise;
       });
 
-      Permission.defineRole('reject-with-redirect', function () {
-        var deferred = $q.defer();
-        deferred.reject({redirectTo: 'redirect'});
-        return deferred.promise;
-      });
-
       Permission.defineRole('reject-with-object', function () {
         var deferred = $q.defer();
         deferred.reject({hello: 'world'});
@@ -369,9 +363,9 @@ describe('Service: Permission', function () {
       spyOn(callbacks, 'reject');
       spyOn(callbacks, 'resolve');
 
-      // test some permutations
+      // test the permutations
 
-      Permission.resolveIfAllMatch(['user', 'reject-with-redirect', 'reject-no-redirect']).then(callbacks.resolve, callbacks.reject);
+      Permission.resolveIfAllMatch(['user', 'reject-no-redirect']).then(callbacks.resolve, callbacks.reject);
       $rootScope.$digest();
 
       expect(callbacks.reject).toHaveBeenCalled();
@@ -381,17 +375,7 @@ describe('Service: Permission', function () {
       spyOn(callbacks, 'reject');
       spyOn(callbacks, 'resolve');
 
-      Permission.resolveIfAllMatch(['user', 'reject-no-redirect', 'reject-with-redirect']).then(callbacks.resolve, callbacks.reject);
-      $rootScope.$digest();
-
-      expect(callbacks.reject).toHaveBeenCalled();
-      expect(callbacks.resolve).not.toHaveBeenCalled();
-
-      callbacks = {reject: function () {}, resolve: function () {}};
-      spyOn(callbacks, 'reject');
-      spyOn(callbacks, 'resolve');
-
-      Permission.resolveIfAllMatch(['reject-no-redirect', 'user', 'reject-with-redirect']).then(callbacks.resolve, callbacks.reject);
+      Permission.resolveIfAllMatch(['reject-no-redirect', 'user']).then(callbacks.resolve, callbacks.reject);
       $rootScope.$digest();
 
       expect(callbacks.reject).toHaveBeenCalled();
@@ -403,49 +387,12 @@ describe('Service: Permission', function () {
       spyOn(callbacks, 'reject');
       spyOn(callbacks, 'resolve');
 
-      Permission.resolveIfAllMatch(['reject-with-object', 'reject-with-redirect', 'reject-no-redirect']).then(callbacks.resolve, callbacks.reject);
+      Permission.resolveIfAllMatch(['reject-with-object', 'reject-no-redirect']).then(callbacks.resolve, callbacks.reject);
       $rootScope.$digest();
 
       expect(callbacks.reject).toHaveBeenCalled();
       expect(callbacks.resolve).not.toHaveBeenCalled();
     });
-
-    it('should reject and forward the redirectTo property if available', function () {
-      var callbacks = {reject: function () {}, resolve: function () {}};
-      spyOn(callbacks, 'reject');
-      spyOn(callbacks, 'resolve');
-
-      Permission.resolveIfAllMatch(['admin', 'user', 'reject-with-redirect']).then(callbacks.resolve, callbacks.reject);
-      $rootScope.$digest();
-
-      expect(callbacks.reject).toHaveBeenCalledWith({redirectTo: 'redirect'});
-      expect(callbacks.resolve).not.toHaveBeenCalled();
-    });
-
-    it('should reject and not provide the redirectTo property if it is not available but another reason was given', function () {
-      var callbacks = {reject: function () {}, resolve: function () {}};
-      spyOn(callbacks, 'reject');
-      spyOn(callbacks, 'resolve');
-
-      Permission.resolveIfAllMatch(['admin', 'user', 'reject-with-object']).then(callbacks.resolve, callbacks.reject);
-      $rootScope.$digest();
-
-      expect(callbacks.reject).toHaveBeenCalledWith(undefined);
-      expect(callbacks.resolve).not.toHaveBeenCalled();
-    });
-
-   it('should reject and not provide the redirectTo property if it is not available and no reason was given', function () {
-      var callbacks = {reject: function () {}, resolve: function () {}};
-      spyOn(callbacks, 'reject');
-      spyOn(callbacks, 'resolve');
-
-      Permission.resolveIfAllMatch(['admin', 'user', 'reject-no-redirect']).then(callbacks.resolve, callbacks.reject);
-      $rootScope.$digest();
-
-      expect(callbacks.reject).toHaveBeenCalledWith(undefined);
-      expect(callbacks.resolve).not.toHaveBeenCalled();
-    });
-
 
   });
 

--- a/src/permission.svc.test.js
+++ b/src/permission.svc.test.js
@@ -77,6 +77,31 @@ describe('Service: Permission', function () {
         }
         return deferred.promise;
       });
+
+      // used for check all
+      Permission.defineRole('resolve', function () {
+        var deferred = $q.defer();
+        deferred.resolve();
+        return deferred.promise;
+      });
+
+      Permission.defineRole('reject-no-redirect', function () {
+        var deferred = $q.defer();
+        deferred.reject();
+        return deferred.promise;
+      });
+
+      Permission.defineRole('reject-with-redirect', function () {
+        var deferred = $q.defer();
+        deferred.reject({redirectTo: 'redirect'});
+        return deferred.promise;
+      });
+
+      Permission.defineRole('reject-with-object', function () {
+        var deferred = $q.defer();
+        deferred.reject({hello: 'world'});
+        return deferred.promise;
+      });            
     };
   });
 
@@ -164,7 +189,7 @@ describe('Service: Permission', function () {
     });
 
     it('should throw an exception if param doesn\'t have "only" or "except" keys', function () {
-      var exception = new Error('Either "only" or "except" keys must me defined');
+      var exception = new Error('Either "only", "except" or "all" keys must me defined');
       expect(function () {
         Permission._validateRoleMap({});
       }).toThrow(exception);
@@ -289,4 +314,139 @@ describe('Service: Permission', function () {
       expect(callbacks.resolve).not.toHaveBeenCalled();
     });
   });
+
+  describe('#resolveIfAllMatch - Array', function () {
+    beforeEach(function () {defineRolesHelper();});
+
+    it('should resolve if all roles match', function () {
+      var callbacks = {reject: function () {}, resolve: function () {}};
+      spyOn(callbacks, 'reject');
+      spyOn(callbacks, 'resolve');
+
+      Permission.resolveIfAllMatch(['user', 'admin', 'resolve']).then(callbacks.resolve, callbacks.reject);
+      $rootScope.$digest();
+
+      expect(callbacks.reject).not.toHaveBeenCalled();
+      expect(callbacks.resolve).toHaveBeenCalled();
+    });
+
+    it('should reject if one role rejects', function () {
+      var callbacks = {reject: function () {}, resolve: function () {}};
+      spyOn(callbacks, 'reject');
+      spyOn(callbacks, 'resolve');
+
+      // test some permutations
+
+      Permission.resolveIfAllMatch(['user', 'admin', 'reject-no-redirect']).then(callbacks.resolve, callbacks.reject);
+      $rootScope.$digest();
+
+      expect(callbacks.reject).toHaveBeenCalled();
+      expect(callbacks.resolve).not.toHaveBeenCalled();
+
+      callbacks = {reject: function () {}, resolve: function () {}};
+      spyOn(callbacks, 'reject');
+      spyOn(callbacks, 'resolve');
+
+      Permission.resolveIfAllMatch(['user', 'reject-no-redirect', 'admin']).then(callbacks.resolve, callbacks.reject);
+      $rootScope.$digest();
+
+      expect(callbacks.reject).toHaveBeenCalled();
+      expect(callbacks.resolve).not.toHaveBeenCalled();
+
+      callbacks = {reject: function () {}, resolve: function () {}};
+      spyOn(callbacks, 'reject');
+      spyOn(callbacks, 'resolve');
+
+      Permission.resolveIfAllMatch(['reject-no-redirect', 'user', 'admin']).then(callbacks.resolve, callbacks.reject);
+      $rootScope.$digest();
+
+      expect(callbacks.reject).toHaveBeenCalled();
+      expect(callbacks.resolve).not.toHaveBeenCalled();
+    });
+
+    it('should reject if two of three reject', function () {
+      var callbacks = {reject: function () {}, resolve: function () {}};
+      spyOn(callbacks, 'reject');
+      spyOn(callbacks, 'resolve');
+
+      // test some permutations
+
+      Permission.resolveIfAllMatch(['user', 'reject-with-redirect', 'reject-no-redirect']).then(callbacks.resolve, callbacks.reject);
+      $rootScope.$digest();
+
+      expect(callbacks.reject).toHaveBeenCalled();
+      expect(callbacks.resolve).not.toHaveBeenCalled();
+
+      callbacks = {reject: function () {}, resolve: function () {}};
+      spyOn(callbacks, 'reject');
+      spyOn(callbacks, 'resolve');
+
+      Permission.resolveIfAllMatch(['user', 'reject-no-redirect', 'reject-with-redirect']).then(callbacks.resolve, callbacks.reject);
+      $rootScope.$digest();
+
+      expect(callbacks.reject).toHaveBeenCalled();
+      expect(callbacks.resolve).not.toHaveBeenCalled();
+
+      callbacks = {reject: function () {}, resolve: function () {}};
+      spyOn(callbacks, 'reject');
+      spyOn(callbacks, 'resolve');
+
+      Permission.resolveIfAllMatch(['reject-no-redirect', 'user', 'reject-with-redirect']).then(callbacks.resolve, callbacks.reject);
+      $rootScope.$digest();
+
+      expect(callbacks.reject).toHaveBeenCalled();
+      expect(callbacks.resolve).not.toHaveBeenCalled();
+    });
+
+    it('should reject if three of three reject', function () {
+      var callbacks = {reject: function () {}, resolve: function () {}};
+      spyOn(callbacks, 'reject');
+      spyOn(callbacks, 'resolve');
+
+      Permission.resolveIfAllMatch(['reject-with-object', 'reject-with-redirect', 'reject-no-redirect']).then(callbacks.resolve, callbacks.reject);
+      $rootScope.$digest();
+
+      expect(callbacks.reject).toHaveBeenCalled();
+      expect(callbacks.resolve).not.toHaveBeenCalled();
+    });
+
+    it('should reject and forward the redirectTo property if available', function () {
+      var callbacks = {reject: function () {}, resolve: function () {}};
+      spyOn(callbacks, 'reject');
+      spyOn(callbacks, 'resolve');
+
+      Permission.resolveIfAllMatch(['admin', 'user', 'reject-with-redirect']).then(callbacks.resolve, callbacks.reject);
+      $rootScope.$digest();
+
+      expect(callbacks.reject).toHaveBeenCalledWith({redirectTo: 'redirect'});
+      expect(callbacks.resolve).not.toHaveBeenCalled();
+    });
+
+    it('should reject and not provide the redirectTo property if it is not available but another reason was given', function () {
+      var callbacks = {reject: function () {}, resolve: function () {}};
+      spyOn(callbacks, 'reject');
+      spyOn(callbacks, 'resolve');
+
+      Permission.resolveIfAllMatch(['admin', 'user', 'reject-with-object']).then(callbacks.resolve, callbacks.reject);
+      $rootScope.$digest();
+
+      expect(callbacks.reject).toHaveBeenCalledWith(undefined);
+      expect(callbacks.resolve).not.toHaveBeenCalled();
+    });
+
+   it('should reject and not provide the redirectTo property if it is not available and no reason was given', function () {
+      var callbacks = {reject: function () {}, resolve: function () {}};
+      spyOn(callbacks, 'reject');
+      spyOn(callbacks, 'resolve');
+
+      Permission.resolveIfAllMatch(['admin', 'user', 'reject-no-redirect']).then(callbacks.resolve, callbacks.reject);
+      $rootScope.$digest();
+
+      expect(callbacks.reject).toHaveBeenCalledWith(undefined);
+      expect(callbacks.resolve).not.toHaveBeenCalled();
+    });
+
+
+  });
+
 });


### PR DESCRIPTION
In reference to Narzerus/angular-permission#12

**tl;dr**: Needed it myself. Implemented it. Pushed it to a new branch for review.

Hmm. I thought I could propose a new branch. Sorry I don't know how to do it, so sadly I will crate this pull request for the development branch.

Short preface
------------------
I have to confess, that I always thought that the only permission was 'allOfThese' instead the 'oneOfThese' permission. Partly because I only had one role. 'isLoggedIn'. As soon as I needed a second role, I needed this functionality myself. Today I had too much time on my hands and implemented such a functionality.

The added API
-------------------

```javascript
$stateProvider.state('restricted', {
	data: {
		permissions: {
			all: ['roleA', 'roleB'],
			redirectTo: 'redirectToThisState'
		}			
	}
});
```

Just like expected. The state only changes if both `roleA` and `roleB` are resolved, otherwise the user will be redirected to `redirectToThisState`.


As soon as I added this feature I felt the need that you could provide separate `redirectTo`s for the different roles:

```javascript
$stateProvider.state('restricted', {
	data: {
		permissions: {
			all: {
				'roleA': {}, 
				'roleB': {
					redirectTo: 'stateB'
				}
			},
			redirectTo: 'stateC'	
		}
	}
});
``` 

Along with the array notation it is possible for the `all` property to receive an object. This one is a bit more complicated:
The state will successfully change to `restricted` if both roles are resolved. But if `roleB` is rejected the state will change to `stateB` instead. If `roleA` or another role, that doesn't explicitly have a `redirectTo` state, rejects then the default `redirectTo` will take place and the state will change to `stateC`.

I also have an alternative approach:
You can directly specify the route that the user shall be redirected to in the rejection function of the role. An example:

The role:
```javascript
Permission.defineRole('roleC', function () {
	var deferred = $q.defer();
	deferred.reject({redirectTo: 'stateA'});
  	return deferred.promise;
});
``` 
The state:
```javascript
$stateProvider.state('restricted', {
	data: {
		permissions: {
			all: ['roleC'],		
			redirectTo: 'stateB'	
		}
	}
});
``` 

The roles can be provided via the array or the object notation. If `roleC` rejects the state will be redirected to `stateA` as stated in the role and not to `stateB` as written in the state object.

Currently I have implemented both versions into one.

The role:
```javascript
Permission.defineRole('roleC', function () {
	var deferred = $q.defer();
	deferred.reject({redirectTo: 'stateA'});
  	return deferred.promise;
});
``` 
The state:
```javascript
$stateProvider.state('restricted', {
	data: {
		permissions: {
			all: {
				roleA: {},
				roleC: {
					redirectTo: 'stateY'
				}
			},		
			redirectTo: 'stateB'	
		}
	}
});
``` 

The if `roleC` rejects the state would be redirected to `stateA` as the role says. So the order is:
`redirectTo` in rejection > `redirectTo` as property of role in the state > `redirectTo` as property of the state.
