### PR TITLE
Added "toParams" to the redirect

### DIFF
--- a/dist/angular-permission.js
+++ b/dist/angular-permission.js
@@ -1,7 +1,7 @@
 /**
  * angular-permission
  * Route permission and access control as simple as it can get
- * @version v0.1.5 - 2014-11-09
+ * @version v0.1.5 - 2014-11-23
  * @link http://www.rafaelvidaurre.com
  * @author Rafael Vidaurre <narzerus@gmail.com>
  * @license MIT License, http://www.opensource.org/licenses/MIT
@@ -51,7 +51,7 @@
               // If not authorized, redirect to wherever the route has defined, if defined at all
               var redirectTo = permissions.redirectTo;
               if (redirectTo) {
-                $state.go(redirectTo, {}, {notify: false}).then(function() {
+                $state.go(redirectTo, toParams, {notify: false}).then(function() {
                   $rootScope
                     .$broadcast('$stateChangeSuccess', toState, toParams, fromState, fromParams);
                 });

--- a/src/permission.mdl.js
+++ b/src/permission.mdl.js
@@ -42,7 +42,7 @@
               // If not authorized, redirect to wherever the route has defined, if defined at all
               var redirectTo = permissions.redirectTo;
               if (redirectTo) {
-                $state.go(redirectTo, {}, {notify: false}).then(function() {
+                $state.go(redirectTo, toParams, {notify: false}).then(function() {
                   $rootScope
                     .$broadcast('$stateChangeSuccess', toState, toParams, fromState, fromParams);
                 });

--- a/src/permission.mdl.test.js
+++ b/src/permission.mdl.test.js
@@ -95,6 +95,23 @@ describe('Module: Permission', function () {
         }
       }
     });
+    
+    $stateProvider.state('abstractTest', {
+      abstract: true,
+      url: ':abstractValue'
+    });
+    $stateProvider.state('abstractTest.redirect', {
+      url: '/abstract'
+    });
+    $stateProvider.state('abstractTest.denied', {
+      url: '/denied',
+      data: {
+        permissions: {
+          only: ['denied'],
+          redirectTo: 'abstractTest.redirect'
+        }
+      }
+    });
   });
 
   describe('On $stateChangeStart', function () {
@@ -152,6 +169,25 @@ describe('Module: Permission', function () {
       });
       $rootScope.$digest();
       expect($state.current.name).toBe('redirectToThisState');
+      expect(changePermissionAcceptedHasBeenCalled).not.toBeTruthy();
+      expect(changePermissionDeniedHasBeenCalled).toBeTruthy();
+    });
+    
+    it('should pass state params on redirect', function () {
+      initStateTo('home');
+      $state.go('abstractTest.denied',{abstractValue: 'test'});
+      var changePermissionAcceptedHasBeenCalled = false;
+      $rootScope.$on('$stateChangePermissionAccepted', function () {
+        changePermissionAcceptedHasBeenCalled = true;
+      });
+      
+      var changePermissionDeniedHasBeenCalled = false;
+      $rootScope.$on('$stateChangePermissionDenied', function () {
+        changePermissionDeniedHasBeenCalled = true;
+      });
+      $rootScope.$digest();
+      expect($state.current.name).toBe('abstractTest.redirect');
+      expect($state.params.abstractValue).toBe('test');
       expect(changePermissionAcceptedHasBeenCalled).not.toBeTruthy();
       expect(changePermissionDeniedHasBeenCalled).toBeTruthy();
     });


### PR DESCRIPTION
This ensures that existing parameters required for abstract parent states are preserved.

I made the (very minor) change, as well as adding a new test cases specifically for this issue.

This PR replaces/closes issue #17
