### PR TITLE
fix redirect event not being correctly triggered

### DIFF
--- a/dist/angular-permission.js
+++ b/dist/angular-permission.js
@@ -51,10 +51,7 @@
               // If not authorized, redirect to wherever the route has defined, if defined at all
               var redirectTo = permissions.redirectTo;
               if (redirectTo) {
-                $state.go(redirectTo, toParams, {notify: false}).then(function() {
-                  $rootScope
-                    .$broadcast('$stateChangeSuccess', toState, toParams, fromState, fromParams);
-                });
+                $state.go(redirectTo, toParams);
               }
             }
           });

--- a/src/permission.mdl.js
+++ b/src/permission.mdl.js
@@ -42,10 +42,7 @@
               // If not authorized, redirect to wherever the route has defined, if defined at all
               var redirectTo = permissions.redirectTo;
               if (redirectTo) {
-                $state.go(redirectTo, toParams, {notify: false}).then(function() {
-                  $rootScope
-                    .$broadcast('$stateChangeSuccess', toState, toParams, fromState, fromParams);
-                });
+                $state.go(redirectTo, toParams);
               }
             }
           });

--- a/src/permission.mdl.test.js
+++ b/src/permission.mdl.test.js
@@ -178,6 +178,17 @@ describe('Module: Permission', function () {
       expect(changePermissionDeniedHasBeenCalled).toBeTruthy();
     });
 
+    it('should trigger $stateChangeSuccess with the redirect state and not the denied one', function () {
+      initStateTo('home');
+      $state.go('deniedWithRedirect');
+
+      $rootScope.$on('$stateChangeSuccess', function (name, toState) {
+        expect(toState.name).not.toBe('deniedWithRedirect');
+        expect(toState.name).toBe('redirectToThisState');
+      });
+      $rootScope.$digest();
+    });
+
     it('should pass state params on redirect', function () {
       initStateTo('home');
       $state.go('abstractTest.denied',{abstractValue: 'test'});


### PR DESCRIPTION
I think the rationale of triggering manually `$stateChangeSuccess` was pointless for the redirect.
It ended up resulting in an inconsistent event trigger, with the actual state redirecting to being the one specified in `permission.redirectTo`, but the state passed to the events being the current `toState`, which is the denied state.