### PR TITLE
Bump angular-ui-router dependecy to latest available

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,6 +27,6 @@
     "angular-mocks": "*"
   },
   "dependencies": {
-    "angular-ui-router": "0.2.11"
+    "angular-ui-router": "~0.2.11"
   }
 }

--- a/dist/angular-permission.js
+++ b/dist/angular-permission.js
@@ -1,7 +1,7 @@
 /**
  * angular-permission
  * Route permission and access control as simple as it can get
- * @version v0.1.6 - 2014-11-24
+ * @version v0.1.6 - 2014-12-01
  * @link http://www.rafaelvidaurre.com
  * @author Rafael Vidaurre <narzerus@gmail.com>
  * @license MIT License, http://www.opensource.org/licenses/MIT


### PR DESCRIPTION
It was hardcoded to 0.2.11 in latest release. Any reason behind it or just mistype?