### PR TITLE
fix wrong parameters of $stateChangeStart

### DIFF
--- a/dist/angular-permission.js
+++ b/dist/angular-permission.js
@@ -1,7 +1,7 @@
 /**
  * angular-permission
  * Route permission and access control as simple as it can get
- * @version v0.1.7 - 2015-02-16
+ * @version v0.1.7 - 2015-02-28
  * @link http://www.rafaelvidaurre.com
  * @author Rafael Vidaurre <narzerus@gmail.com>
  * @license MIT License, http://www.opensource.org/licenses/MIT
@@ -14,6 +14,10 @@
     .run(['$rootScope', 'Permission', '$state', function ($rootScope, Permission, $state) {
       $rootScope.$on('$stateChangeStart',
       function (event, toState, toParams, fromState, fromParams) {
+        if (toState.$$finishAuthorize) {
+          return;
+        }
+
         // If there are permissions set then prevent default and attempt to authorize
         var permissions;
         if (toState.data && toState.data.permissions) {
@@ -31,12 +35,13 @@
 
         if (permissions) {
           event.preventDefault();
+          toState = angular.extend({'$$finishAuthorize': true}, toState);
 
           Permission.authorize(permissions, toParams).then(function () {
             // If authorized, use call state.go without triggering the event.
             // Then trigger $stateChangeSuccess manually to resume the rest of the process
             // Note: This is a pseudo-hacky fix which should be fixed in future ui-router versions
-            if (!$rootScope.$broadcast('$stateChangeStart', toState.name, toParams, fromState.name, fromParams).defaultPrevented) {
+            if (!$rootScope.$broadcast('$stateChangeStart', toState, toParams, fromState, fromParams).defaultPrevented) {
               $rootScope.$broadcast('$stateChangePermissionAccepted', toState, toParams);
 
               $state.go(toState.name, toParams, {notify: false}).then(function() {
@@ -45,7 +50,7 @@
               });
             }
           }, function () {
-            if (!$rootScope.$broadcast('$stateChangeStart', toState.name, toParams, fromState.name, fromParams).defaultPrevented) {
+            if (!$rootScope.$broadcast('$stateChangeStart', toState, toParams, fromState, fromParams).defaultPrevented) {
               $rootScope.$broadcast('$stateChangePermissionDenied', toState, toParams);
 
               // If not authorized, redirect to wherever the route has defined, if defined at all

--- a/src/permission.mdl.test.js
+++ b/src/permission.mdl.test.js
@@ -134,11 +134,30 @@ describe('Module: Permission', function () {
         changePermissionDeniedHasBeenCalled = true;
       });
 
-
       $rootScope.$digest();
       expect($state.current.name).toBe('accepted');
       expect(changePermissionAcceptedHasBeenCalled).toBeTruthy();
       expect(changePermissionDeniedHasBeenCalled).not.toBeTruthy();
+    }));
+
+    it('should broadcast a $stateChangeStart with correct parameters(accepted state)', inject (function($rootScope) {
+      initStateTo('home');
+      $state.go('accepted');
+
+      var changeStartHasBeenCalled = false;
+      var toState = null;
+      var fromState = null;
+      $rootScope.$on('$stateChangeStart', function (event, _toState, toParams, _fromState, fromParams) {
+        changeStartHasBeenCalled = true;
+        toState = _toState;
+        fromState = _fromState;
+      });
+
+      $rootScope.$digest();
+      expect($state.current.name).toBe('accepted');
+      expect(changeStartHasBeenCalled).toBeTruthy();
+      expect(toState.name).toBe('accepted');
+      expect(fromState.name).toBe('home');
     }));
 
     it('should not go to the denied state', function () {
@@ -159,6 +178,26 @@ describe('Module: Permission', function () {
       expect(changePermissionAcceptedHasBeenCalled).not.toBeTruthy();
       expect(changePermissionDeniedHasBeenCalled).toBeTruthy();
     });
+
+    it('should broadcast a $stateChangeStart with correct parameters(denied state)', inject (function($rootScope) {
+      initStateTo('home');
+      $state.go('denied');
+
+      var changeStartHasBeenCalled = false;
+      var toState = null;
+      var fromState = null;
+      $rootScope.$on('$stateChangeStart', function (event, _toState, toParams, _fromState, fromParams) {
+        changeStartHasBeenCalled = true;
+        toState = _toState;
+        fromState = _fromState;
+      });
+
+      $rootScope.$digest();
+      expect($state.current.name).toBe('home');
+      expect(changeStartHasBeenCalled).toBeTruthy();
+      expect(toState.name).toBe('denied');
+      expect(fromState.name).toBe('home');
+    }));
 
     it('should not go to the denied state but redirect to the provided state', function () {
       initStateTo('home');


### PR DESCRIPTION
I find that angular-permission broadcast a `$stateChangeStart` with wrong parameters.
The `toState` and `fromState` is a object of state.
But angular-permission broadcast with a state's name.

I add a `$$finishAuthorize` for prevent infinite loop.