### PR TITLE
add $stateChangePermissionStart.

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ it allows you to define this behaviour however you want to.
 
 Events
 ------
+- **$stateChangePermissionStart**: This event is broadcasted before perform authorize.
+
 - **$stateChangePermissionAccepted**: This event is broadcasted when one of the permissions has been accepted and the state changes successfully.
 
 - **$stateChangePermissionDenied**: This event is broadcasted when the access to the target state is not granted (no permissions found on the `only` array or at least one permission found on the `except` array). This is when the state stays the same or is changed based on the `redirectTo` option.

--- a/dist/angular-permission.js
+++ b/dist/angular-permission.js
@@ -1,7 +1,7 @@
 /**
  * angular-permission
  * Route permission and access control as simple as it can get
- * @version v0.2.0 - 2015-03-02
+ * @version v0.2.0 - 2015-03-03
  * @link http://www.rafaelvidaurre.com
  * @author Rafael Vidaurre <narzerus@gmail.com>
  * @license MIT License, http://www.opensource.org/licenses/MIT
@@ -36,6 +36,10 @@
         if (permissions) {
           event.preventDefault();
           toState = angular.extend({'$$finishAuthorize': true}, toState);
+
+          if ($rootScope.$broadcast('$stateChangePermissionStart', toState, toParams).defaultPrevented) {
+            return;
+          }
 
           Permission.authorize(permissions, toParams).then(function () {
             // If authorized, use call state.go without triggering the event.

--- a/src/permission.mdl.js
+++ b/src/permission.mdl.js
@@ -28,6 +28,10 @@
           event.preventDefault();
           toState = angular.extend({'$$finishAuthorize': true}, toState);
 
+          if ($rootScope.$broadcast('$stateChangePermissionStart', toState, toParams).defaultPrevented) {
+            return;
+          }
+
           Permission.authorize(permissions, toParams).then(function () {
             // If authorized, use call state.go without triggering the event.
             // Then trigger $stateChangeSuccess manually to resume the rest of the process

--- a/src/permission.mdl.test.js
+++ b/src/permission.mdl.test.js
@@ -160,6 +160,46 @@ describe('Module: Permission', function () {
       expect(fromState.name).toBe('home');
     }));
 
+    it('should broadcast a $stateChangePermissionStart', inject(function($rootScope) {
+      initStateTo('home');
+
+      var changePermissionStartHasBeenCalled = false;
+      var toState = null;
+      $rootScope.$on('$stateChangePermissionStart', function (event, _toState) {
+        changePermissionStartHasBeenCalled = true;
+        toState = _toState;
+      });
+
+      $state.go('accepted');
+      $rootScope.$digest();
+      expect(changePermissionStartHasBeenCalled).toBeTruthy();
+      expect(toState.name).toBe('accepted');
+    }));
+
+    it('should not go to a state when $stateChangePermissionStart has been cancelled', function() {
+      initStateTo('home');
+
+      $rootScope.$on('$stateChangePermissionStart', function (event) {
+        event.preventDefault();
+      });
+
+      $state.go('accepted');
+      var changePermissionAcceptedHasBeenCalled = false;
+      $rootScope.$on('$stateChangePermissionAccepted', function () {
+        changePermissionAcceptedHasBeenCalled = true;
+      });
+
+      var changePermissionDeniedHasBeenCalled = false;
+      $rootScope.$on('$stateChangePermissionDenied', function () {
+        changePermissionDeniedHasBeenCalled = true;
+      });
+
+      $rootScope.$digest();
+      expect($state.current.name).toBe('home');
+      expect(changePermissionAcceptedHasBeenCalled).not.toBeTruthy();
+      expect(changePermissionDeniedHasBeenCalled).not.toBeTruthy();
+    });
+
     it('should not go to the denied state', function () {
       initStateTo('home');
       $state.go('denied');


### PR DESCRIPTION
If server API response like below format.
```json
{
  "id": 1,
  "name": "flyskyko",
  "role": "admin"
}
```

State like
```javascript
$stateProvider.state({
  name: 'admin',
  data: {
    permissions: {
      only: ['owner', 'admin']
    }
  }
});
```

Permission like
```javascript
Permission
  .defineRole('owner', function () {
    memberResource.get({id: 1}).$promise.then(function(member) {
      if (member.role === 'owner') {
        $q.resolve();
      } else {
        $q.reject();
      }
    });
  .defineRole('admin', function () {
    memberResource.get({id: 1}).$promise.then(function(member) {
      if (member.role === 'admin') {
        $q.resolve();
      } else {
        $q.reject();
      }
    });
  })
```

If user's role is `member`, angular-permission call both function of owner and admin.
It makes two request.

If I use a service for current user information, It also have a problem.
I want to check a permission every change of state that have a permissions.
But, current version of angular-permission have a no point to refresh a current user information.

Because of this, I add a $stateChangePermissionStart.