### PR TITLE
Dynamic redirects based on role

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,25 @@ Another thing you can do is set a redirect url to which unauthorized sessions wi
     });
 ```
 
+You can also redirect dynamically based on the current role
+
+```javascript
+  $stateProvider
+    .state('dashboard', {
+      url: '...',
+      data: {
+        permissions: {
+          except: ['guest'],
+          redirectTo: {
+            user: 'user.index',
+            admin: 'admin.index',
+            otherwise: 'home'
+          }
+        }
+      }
+    });
+```
+
 
 Defining roles
 --------------------------

--- a/dist/angular-permission.js
+++ b/dist/angular-permission.js
@@ -1,7 +1,7 @@
 /**
  * angular-permission
  * Route permission and access control as simple as it can get
- * @version v0.1.6 - 2014-12-01
+ * @version v0.1.6 - 2015-02-16
  * @link http://www.rafaelvidaurre.com
  * @author Rafael Vidaurre <narzerus@gmail.com>
  * @license MIT License, http://www.opensource.org/licenses/MIT
@@ -51,10 +51,27 @@
               // If not authorized, redirect to wherever the route has defined, if defined at all
               var redirectTo = permissions.redirectTo;
               if (redirectTo) {
-                $state.go(redirectTo, toParams, {notify: false}).then(function() {
-                  $rootScope
+                var state = undefined;
+                if (redirectTo === Object(redirectTo)) {
+                  for (var role in redirectTo) {
+                    if (Permission.roleValidations.hasOwnProperty(role) && Permission.roleValidations[role]()) {
+                      state = redirectTo[role];
+                      break; 
+                    }
+                  }
+                  // If no state is authorized then check for otherwise
+                  if (state == undefined && redirectTo.hasOwnProperty('otherwise')) {
+                    state = redirectTo['otherwise'];
+                  }
+                } else {
+                  state = redirectTo;
+                }
+                if (state) {
+                  $state.go(state, toParams, {notify: false}).then(function() {
+                    $rootScope
                     .$broadcast('$stateChangeSuccess', toState, toParams, fromState, fromParams);
-                });
+                  });
+                }
               }
             }
           });

--- a/src/permission.mdl.js
+++ b/src/permission.mdl.js
@@ -42,10 +42,27 @@
               // If not authorized, redirect to wherever the route has defined, if defined at all
               var redirectTo = permissions.redirectTo;
               if (redirectTo) {
-                $state.go(redirectTo, toParams, {notify: false}).then(function() {
-                  $rootScope
+                var state = undefined;
+                if (redirectTo === Object(redirectTo)) {
+                  for (var role in redirectTo) {
+                    if (Permission.roleValidations.hasOwnProperty(role) && Permission.roleValidations[role]()) {
+                      state = redirectTo[role];
+                      break; 
+                    }
+                  }
+                  // If no state is authorized then check for otherwise
+                  if (state == undefined && redirectTo.hasOwnProperty('otherwise')) {
+                    state = redirectTo['otherwise'];
+                  }
+                } else {
+                  state = redirectTo;
+                }
+                if (state) {
+                  $state.go(state, toParams, {notify: false}).then(function() {
+                    $rootScope
                     .$broadcast('$stateChangeSuccess', toState, toParams, fromState, fromParams);
-                });
+                  });
+                }
               }
             }
           });

--- a/src/permission.mdl.test.js
+++ b/src/permission.mdl.test.js
@@ -83,6 +83,18 @@ describe('Module: Permission', function () {
       }
     });
 
+    $stateProvider.state('deniedWithMultipleRedirect', {
+      data: {
+        permissions: {
+          only: ['denied'],
+          redirectTo: {
+            accepted: 'accepted',
+            otherwhise: 'home'
+          }
+        }
+      }
+    });
+
     $stateProvider.state('onlyWithParams', {
       url: ':isset',
       data: {
@@ -285,6 +297,23 @@ describe('Module: Permission', function () {
       expect(changePermissionDeniedHasBeenCalled).not.toBeTruthy();
     });
 
+    it('should not go to the denied state but redirect to the provided state identified by the role', function () {
+      initStateTo('home');
+      $state.go('deniedWithMultipleRedirect');
+      var changePermissionAcceptedHasBeenCalled = false;
+      $rootScope.$on('$stateChangePermissionAccepted', function () {
+        changePermissionAcceptedHasBeenCalled = true;
+      });
+
+      var changePermissionDeniedHasBeenCalled = false;
+      $rootScope.$on('$stateChangePermissionDenied', function () {
+        changePermissionDeniedHasBeenCalled = true;
+      });
+      $rootScope.$digest();
+      expect($state.current.name).toBe('accepted');
+      expect(changePermissionAcceptedHasBeenCalled).not.toBeTruthy();
+      expect(changePermissionDeniedHasBeenCalled).toBeTruthy();
+    });
 
   });
 


### PR DESCRIPTION
You can now create a object rather than just a state name for the redirect option. The object uses the role name as the key and state as the value. It will redirect to the first role that is authenticated in the list. The 'otherwise' option is optional. If this is specified and no other role is authenticated then it will redirect there.