### PR TITLE
Fix how url changes happen

### DIFF
--- a/dist/angular-permission.js
+++ b/dist/angular-permission.js
@@ -1,7 +1,7 @@
 /**
  * angular-permission
  * Route permission and access control as simple as it can get
- * @version v0.1.7 - 2015-02-16
+ * @version v0.1.7 - 2015-02-26
  * @link http://www.rafaelvidaurre.com
  * @author Rafael Vidaurre <narzerus@gmail.com>
  * @license MIT License, http://www.opensource.org/licenses/MIT
@@ -39,7 +39,7 @@
             if (!$rootScope.$broadcast('$stateChangeStart', toState.name, toParams, fromState.name, fromParams).defaultPrevented) {
               $rootScope.$broadcast('$stateChangePermissionAccepted', toState, toParams);
 
-              $state.go(toState.name, toParams, {notify: false}).then(function() {
+              $state.go(toState.name, toParams, {notify: false, location: false}).then(function() {
                 $rootScope
                   .$broadcast('$stateChangeSuccess', toState, toParams, fromState, fromParams);
               });

--- a/src/permission.mdl.js
+++ b/src/permission.mdl.js
@@ -30,7 +30,7 @@
             if (!$rootScope.$broadcast('$stateChangeStart', toState.name, toParams, fromState.name, fromParams).defaultPrevented) {
               $rootScope.$broadcast('$stateChangePermissionAccepted', toState, toParams);
 
-              $state.go(toState.name, toParams, {notify: false}).then(function() {
+              $state.go(toState.name, toParams, {notify: false, location: false}).then(function() {
                 $rootScope
                   .$broadcast('$stateChangeSuccess', toState, toParams, fromState, fromParams);
               });


### PR DESCRIPTION
Currently, when $state.go is called the new url isn't updated properly. If
query parameters exist on the url they're removed because $state.go is called
with only the toState name.

There's an option for $state.go to not update the url which I enabled on
the successful validation of a permission (since you're not really going to
a new URL anyways). This leaves query parameters intact.