### PR TITLE
More powerful redirections

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,3 @@
+{
+  "directory": "bower_components"
+}

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-permission",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "authors": [
     "Rafael Vidaurre <narzerus@gmail.com>"
   ],
@@ -22,6 +22,7 @@
     "tests",
     "src"
   ],
+  "directory": "/",
   "devDependencies": {
     "angular": "*",
     "angular-mocks": "*"

--- a/dist/angular-permission.js
+++ b/dist/angular-permission.js
@@ -1,7 +1,7 @@
 /**
  * angular-permission
  * Route permission and access control as simple as it can get
- * @version v0.2.0 - 2015-03-03
+ * @version v0.3.0 - 2015-06-15
  * @link http://www.rafaelvidaurre.com
  * @author Rafael Vidaurre <narzerus@gmail.com>
  * @license MIT License, http://www.opensource.org/licenses/MIT
@@ -11,7 +11,8 @@
   'use strict';
 
   angular.module('permission', ['ui.router'])
-    .run(['$rootScope', 'Permission', '$state', function ($rootScope, Permission, $state) {
+    .run(['$rootScope', 'Permission', '$state', '$q',
+    function ($rootScope, Permission, $state, $q) {
       $rootScope.$on('$stateChangeStart',
       function (event, toState, toParams, fromState, fromParams) {
         if (toState.$$finishAuthorize) {
@@ -57,10 +58,22 @@
             if (!$rootScope.$broadcast('$stateChangeStart', toState, toParams, fromState, fromParams).defaultPrevented) {
               $rootScope.$broadcast('$stateChangePermissionDenied', toState, toParams);
 
-              // If not authorized, redirect to wherever the route has defined, if defined at all
               var redirectTo = permissions.redirectTo;
-              if (redirectTo) {
-                $state.go(redirectTo, toParams);
+              var result;
+
+              if (angular.isFunction(redirectTo)) {
+                redirectTo = redirectTo();
+
+                $q.when(redirectTo).then(function (newState) {
+                  if (newState) {
+                    $state.go(newState, toParams);
+                  }
+                });
+
+              } else {
+                if (redirectTo) {
+                  $state.go(redirectTo, toParams);
+                }
               }
             }
           });

--- a/src/permission.mdl.test.js
+++ b/src/permission.mdl.test.js
@@ -117,6 +117,34 @@ describe('Module: Permission', function () {
         }
       }
     });
+
+    $stateProvider.state('functionRedirect', {
+      url: '/function',
+      data: {
+        permissions: {
+          only: ['denied'],
+          redirectTo: function () {
+            return 'other';
+          }
+        }
+      }
+    });
+
+    $stateProvider.state('functionPromiseRedirect', {
+      url: '/function-promise',
+      data: {
+        permissions: {
+          only: ['denied'],
+          redirectTo: function () {
+            return $q.when('other');
+          }
+        }
+      }
+    });
+
+    $stateProvider.state('other', {
+      url: '/other'
+    })
   });
 
   describe('On $stateChangeStart', function () {
@@ -374,8 +402,24 @@ describe('Module: Permission', function () {
       expect(changePermissionAcceptedHasBeenCalled).not.toBeTruthy();
       expect(changePermissionDeniedHasBeenCalled).not.toBeTruthy();
     });
+  });
 
+  describe('#redirectTo function', function () {
+    it('should redirect based on function if passed', function () {
+      initStateTo('home');
 
+      $state.go('functionRedirect');
+      $rootScope.$digest();
+      expect($state.current.name).toBe('other');
+    });
+
+    it('should redirect with promises as well', function () {
+      initStateTo('home');
+
+      $state.go('functionPromiseRedirect');
+      $rootScope.$digest();
+      expect($state.current.name).toBe('other');
+    });
   });
 
 });

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -18,9 +18,9 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
-      'app/bower_components/angular/angular.js',
-      'app/bower_components/angular-mocks/angular-mocks.js',
-      'app/bower_components/angular-ui-router/release/angular-ui-router.js',
+      'bower_components/angular/angular.js',
+      'bower_components/angular-mocks/angular-mocks.js',
+      'bower_components/angular-ui-router/release/angular-ui-router.js',
       'src/**/*.mdl.js',
       'src/**/*.svc.js',
       'src/**/*.test.js'


### PR DESCRIPTION
Added the ability to pass a function to the `redirectTo` permissions property, this will allow more complex logic behind redirections if needed.

Example:
```javascript
$stateProvider.state('functionRedirect', {
      url: '/function',
      data: {
        permissions: {
          only: ['denied'],
          redirectTo: function () {
            // logic...
            return 'other';
          }
        }
      }
    });
```

The value returned can be a promise or a string, representing the state to which we will redirect, if any other value is passed, no redirection will occur. 