### PR TITLE
Define all your roles with one function call

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,6 @@
     "tests",
     "src"
   ],
-  "directory": "/",
   "devDependencies": {
     "angular": "*",
     "angular-mocks": "*"

--- a/dist/angular-permission.js
+++ b/dist/angular-permission.js
@@ -1,7 +1,7 @@
 /**
  * angular-permission
  * Route permission and access control as simple as it can get
- * @version v0.3.0 - 2015-06-15
+ * @version v0.3.0 - 2015-07-02
  * @link http://www.rafaelvidaurre.com
  * @author Rafael Vidaurre <narzerus@gmail.com>
  * @license MIT License, http://www.opensource.org/licenses/MIT
@@ -97,6 +97,23 @@
         }
       };
 
+      var validateManyRolesDefinitionParams = function(roles, validationFunction) {
+        if (!angular.isArray(roles)) {
+          throw new Error('Roles must be an array');
+        } else {
+          for(var i = 0; i < roles.length; i++) {
+            validateRoleDefinitionParams(roles[i], validationFunction);
+          }
+        }
+      };
+
+      var createManyRolesValidationFunction = function(roleName, validationFunction) {
+         var roleValidator = function() {
+              return validationFunction(roleName);
+          };
+          return roleValidator;
+      };
+
       this.defineRole = function (roleName, validationFunction) {
         /**
           This method is only available in config-time, and cannot access services, as they are
@@ -184,6 +201,17 @@
             roleValidationConfig[roleName] = validationFunction;
 
             return Permission;
+          },
+          defineMany: function(roles, validationFunction) {
+            validateManyRolesDefinitionParams(roles, validationFunction);
+
+            var definedPermissions = Permission;
+            for(var i = 0; i < roles.length; i++) {
+               var validator =  createManyRolesValidationFunction(roles[i], validationFunction);
+               definedPermissions = definedPermissions.defineRole(roles[i], validator);
+            }
+
+            return definedPermissions;
           },
           resolveIfMatch: function (rolesArray, toParams) {
             var roles = angular.copy(rolesArray);

--- a/dist/angular-permission.js
+++ b/dist/angular-permission.js
@@ -107,13 +107,6 @@
         }
       };
 
-      var createManyRolesValidationFunction = function(roleName, validationFunction) {
-         var roleValidator = function() {
-              return validationFunction(roleName);
-          };
-          return roleValidator;
-      };
-
       this.defineRole = function (roleName, validationFunction) {
         /**
           This method is only available in config-time, and cannot access services, as they are
@@ -177,7 +170,7 @@
               throw new Error('undefined role or invalid role validation');
             }
 
-            var validatingRole = Permission.roleValidations[currentRole](toParams);
+            var validatingRole = Permission.roleValidations[currentRole](toParams, currentRole);
             validatingRole = Permission._promiseify(validatingRole);
 
             validatingRole.then(function () {
@@ -207,8 +200,7 @@
 
             var definedPermissions = Permission;
             for(var i = 0; i < roles.length; i++) {
-               var validator =  createManyRolesValidationFunction(roles[i], validationFunction);
-               definedPermissions = definedPermissions.defineRole(roles[i], validator);
+               definedPermissions = definedPermissions.defineRole(roles[i], validationFunction);
             }
 
             return definedPermissions;

--- a/dist/angular-permission.js
+++ b/dist/angular-permission.js
@@ -1,7 +1,7 @@
 /**
  * angular-permission
  * Route permission and access control as simple as it can get
- * @version v0.3.0 - 2015-07-03
+ * @version v0.3.0 - 2015-07-07
  * @link http://www.rafaelvidaurre.com
  * @author Rafael Vidaurre <narzerus@gmail.com>
  * @license MIT License, http://www.opensource.org/licenses/MIT

--- a/dist/angular-permission.js
+++ b/dist/angular-permission.js
@@ -1,7 +1,7 @@
 /**
  * angular-permission
  * Route permission and access control as simple as it can get
- * @version v0.3.0 - 2015-07-02
+ * @version v0.3.0 - 2015-07-03
  * @link http://www.rafaelvidaurre.com
  * @author Rafael Vidaurre <narzerus@gmail.com>
  * @license MIT License, http://www.opensource.org/licenses/MIT
@@ -195,7 +195,7 @@
 
             return Permission;
           },
-          defineMany: function(roles, validationFunction) {
+          defineManyRoles: function(roles, validationFunction) {
             validateManyRolesDefinitionParams(roles, validationFunction);
 
             var definedPermissions = Permission;

--- a/src/permission.svc.js
+++ b/src/permission.svc.js
@@ -23,13 +23,6 @@
         }
       };
 
-      var createManyRolesValidationFunction = function(roleName, validationFunction) {
-         var roleValidator = function() {
-              return validationFunction(roleName);
-          };
-          return roleValidator;
-      };
-
       this.defineRole = function (roleName, validationFunction) {
         /**
           This method is only available in config-time, and cannot access services, as they are
@@ -93,7 +86,7 @@
               throw new Error('undefined role or invalid role validation');
             }
 
-            var validatingRole = Permission.roleValidations[currentRole](toParams);
+            var validatingRole = Permission.roleValidations[currentRole](toParams, currentRole);
             validatingRole = Permission._promiseify(validatingRole);
 
             validatingRole.then(function () {
@@ -123,8 +116,7 @@
 
             var definedPermissions = Permission;
             for(var i = 0; i < roles.length; i++) {
-               var validator =  createManyRolesValidationFunction(roles[i], validationFunction);
-               definedPermissions = definedPermissions.defineRole(roles[i], validator);
+               definedPermissions = definedPermissions.defineRole(roles[i], validationFunction);
             }
 
             return definedPermissions;

--- a/src/permission.svc.js
+++ b/src/permission.svc.js
@@ -111,7 +111,7 @@
 
             return Permission;
           },
-          defineMany: function(roles, validationFunction) {
+          defineManyRoles: function(roles, validationFunction) {
             validateManyRolesDefinitionParams(roles, validationFunction);
 
             var definedPermissions = Permission;

--- a/src/permission.svc.js
+++ b/src/permission.svc.js
@@ -13,6 +13,23 @@
         }
       };
 
+      var validateManyRolesDefinitionParams = function(roles, validationFunction) {
+        if (!angular.isArray(roles)) {
+          throw new Error('Roles must be an array');
+        } else {
+          for(var i = 0; i < roles.length; i++) {
+            validateRoleDefinitionParams(roles[i], validationFunction);
+          }
+        }
+      };
+
+      var createManyRolesValidationFunction = function(roleName, validationFunction) {
+         var roleValidator = function() {
+              return validationFunction(roleName);
+          };
+          return roleValidator;
+      };
+
       this.defineRole = function (roleName, validationFunction) {
         /**
           This method is only available in config-time, and cannot access services, as they are
@@ -100,6 +117,17 @@
             roleValidationConfig[roleName] = validationFunction;
 
             return Permission;
+          },
+          defineMany: function(roles, validationFunction) {
+            validateManyRolesDefinitionParams(roles, validationFunction);
+
+            var definedPermissions = Permission;
+            for(var i = 0; i < roles.length; i++) {
+               var validator =  createManyRolesValidationFunction(roles[i], validationFunction);
+               definedPermissions = definedPermissions.defineRole(roles[i], validator);
+            }
+
+            return definedPermissions;
           },
           resolveIfMatch: function (rolesArray, toParams) {
             var roles = angular.copy(rolesArray);

--- a/src/permission.svc.test.js
+++ b/src/permission.svc.test.js
@@ -96,7 +96,7 @@ describe('Service: Permission', function () {
 
       it('should throw an exception on invalid role name', function () {
         var defineRoleException = new Error('Role name must be a string');
-        var defineManyException = new Error('Roles must be an array');
+        var defineManyRolesException = new Error('Roles must be an array');
         expect(function () {
           PermissionProvider.defineRole(123, function () {});
         }).toThrow(defineRoleException);
@@ -106,19 +106,19 @@ describe('Service: Permission', function () {
         }).toThrow(defineRoleException);
 
         expect(function () {
-          Permission.defineMany(123, function () {});
-        }).toThrow(defineManyException)
+          Permission.defineManyRoles(123, function () {});
+        }).toThrow(defineManyRolesException)
 
         expect(function () {
-          Permission.defineMany(null, function () {});
-        }).toThrow(defineManyException)
+          Permission.defineManyRoles(null, function () {});
+        }).toThrow(defineManyRolesException)
 
         expect(function () {
-          Permission.defineMany('admin', function () {});
-        }).toThrow(defineManyException)
+          Permission.defineManyRoles('admin', function () {});
+        }).toThrow(defineManyRolesException)
 
         expect(function () {
-          Permission.defineMany(['admin', 1], function () {});
+          Permission.defineManyRoles(['admin', 1], function () {});
         }).toThrow(defineRoleException)
 
       });
@@ -142,7 +142,7 @@ describe('Service: Permission', function () {
       });
 
       it('should not throw an exception on valid role name', function () {
-        Permission.defineMany(['admin', 'publisher'], function () {});
+        Permission.defineManyRoles(['admin', 'publisher'], function () {});
       });
     });
   });
@@ -170,14 +170,14 @@ describe('Service: Permission', function () {
   });
 
   describe('#defineManyRoles', function () {
-    it('should define roles on run stage', function () {
+    it('should define many roles on run stage', function () {
      var systemRoles = ['admin', 'publisher', 'user', 'anonymous'];
      var userRoles = ['publisher', 'user'];
 
-      Permission.defineMany(systemRoles, function(stateParams, role){
+      Permission.defineManyRoles(systemRoles, function(stateParams, role){
           var deferred = $q.defer();
           var userHasRole = (userRoles.indexOf(role) != -1);
-          userHasRole ? deferred.reject() : deferred.resolve()
+          userHasRole ?  deferred.resolve() : deferred.reject();
           return deferred.promise;
       });
 

--- a/src/permission.svc.test.js
+++ b/src/permission.svc.test.js
@@ -119,7 +119,7 @@ describe('Service: Permission', function () {
 
         expect(function () {
           Permission.defineMany(['admin', 1], function () {});
-        }).toThrow(defineRoleException)        
+        }).toThrow(defineRoleException)
 
       });
 
@@ -174,7 +174,7 @@ describe('Service: Permission', function () {
      var systemRoles = ['admin', 'publisher', 'user', 'anonymous'];
      var userRoles = ['publisher', 'user'];
 
-      Permission.defineMany(systemRoles, function(role){
+      Permission.defineMany(systemRoles, function(stateParams, role){
           var deferred = $q.defer();
           var userHasRole = (userRoles.indexOf(role) != -1);
           userHasRole ? deferred.reject() : deferred.resolve()
@@ -333,4 +333,3 @@ describe('Service: Permission', function () {
     });
   });
 });
-

--- a/src/permission.svc.test.js
+++ b/src/permission.svc.test.js
@@ -333,3 +333,4 @@ describe('Service: Permission', function () {
     });
   });
 });
+

--- a/src/permission.svc.test.js
+++ b/src/permission.svc.test.js
@@ -10,6 +10,7 @@ describe('Service: Permission', function () {
   var resolveHelper, rejectHelper, defineProviderRolesHelper, defineRolesHelper;
   beforeEach(function () {
     var user = {role: 'admin'};
+
     resolveHelper = function () {
       var deferred = $q.defer();
       deferred.resolve();
@@ -94,14 +95,32 @@ describe('Service: Permission', function () {
     describe('#defineRole (provider version)', function () {
 
       it('should throw an exception on invalid role name', function () {
-        var exception = new Error('Role name must be a string');
+        var defineRoleException = new Error('Role name must be a string');
+        var defineManyException = new Error('Roles must be an array');
         expect(function () {
           PermissionProvider.defineRole(123, function () {});
-        }).toThrow(exception);
+        }).toThrow(defineRoleException);
 
         expect(function () {
           PermissionProvider.defineRole(null, function () {});
-        }).toThrow(exception);
+        }).toThrow(defineRoleException);
+
+        expect(function () {
+          Permission.defineMany(123, function () {});
+        }).toThrow(defineManyException)
+
+        expect(function () {
+          Permission.defineMany(null, function () {});
+        }).toThrow(defineManyException)
+
+        expect(function () {
+          Permission.defineMany('admin', function () {});
+        }).toThrow(defineManyException)
+
+        expect(function () {
+          Permission.defineMany(['admin', 1], function () {});
+        }).toThrow(defineRoleException)        
+
       });
 
       it('should not throw an exception on valid role name', function () {
@@ -120,6 +139,10 @@ describe('Service: Permission', function () {
         expect(angular.isFunction(CustomPermission.roleValidations.anonymous)).toBe(true);
         expect(angular.isFunction(CustomPermission.roleValidations.user)).toBe(true);
         expect(angular.isFunction(CustomPermission.roleValidations.admin)).toBe(true);
+      });
+
+      it('should not throw an exception on valid role name', function () {
+        Permission.defineMany(['admin', 'publisher'], function () {});
       });
     });
   });
@@ -143,6 +166,26 @@ describe('Service: Permission', function () {
       });
       expect(angular.isFunction(Permission.roleValidations.noob)).toBe(true);
       expect(angular.isFunction(Permission.roleValidations.pair)).toBe(true);
+    });
+  });
+
+  describe('#defineManyRoles', function () {
+    it('should define roles on run stage', function () {
+     var systemRoles = ['admin', 'publisher', 'user', 'anonymous'];
+     var userRoles = ['publisher', 'user'];
+
+      Permission.defineMany(systemRoles, function(role){
+          var deferred = $q.defer();
+          var userHasRole = (userRoles.indexOf(role) != -1);
+          userHasRole ? deferred.reject() : deferred.resolve()
+          return deferred.promise;
+      });
+
+      expect(angular.isFunction(Permission.roleValidations.admin)).toBe(true);
+      expect(angular.isFunction(Permission.roleValidations.publisher)).toBe(true);
+      expect(angular.isFunction(Permission.roleValidations.user)).toBe(true);
+      expect(angular.isFunction(Permission.roleValidations.anonymous)).toBe(true);
+
     });
   });
 

--- a/src/permission.svc.test.js
+++ b/src/permission.svc.test.js
@@ -5,6 +5,10 @@ describe('Service: Permission', function () {
   var $q;
   var $rootScope;
   var PermissionProvider;
+  var EXCEPTIONS = {
+    DEFINE_ROLE_EXCEPTION: new Error('Role name must be a string'),
+    DEFINE_MANY_ROLES_EXCEPTION: new Error('Roles must be an array')
+  };
 
   // Helpers
   var resolveHelper, rejectHelper, defineProviderRolesHelper, defineRolesHelper;
@@ -95,32 +99,13 @@ describe('Service: Permission', function () {
     describe('#defineRole (provider version)', function () {
 
       it('should throw an exception on invalid role name', function () {
-        var defineRoleException = new Error('Role name must be a string');
-        var defineManyRolesException = new Error('Roles must be an array');
         expect(function () {
           PermissionProvider.defineRole(123, function () {});
-        }).toThrow(defineRoleException);
+        }).toThrow(EXCEPTIONS.DEFINE_ROLE_EXCEPTION);
 
         expect(function () {
           PermissionProvider.defineRole(null, function () {});
-        }).toThrow(defineRoleException);
-
-        expect(function () {
-          Permission.defineManyRoles(123, function () {});
-        }).toThrow(defineManyRolesException)
-
-        expect(function () {
-          Permission.defineManyRoles(null, function () {});
-        }).toThrow(defineManyRolesException)
-
-        expect(function () {
-          Permission.defineManyRoles('admin', function () {});
-        }).toThrow(defineManyRolesException)
-
-        expect(function () {
-          Permission.defineManyRoles(['admin', 1], function () {});
-        }).toThrow(defineRoleException)
-
+        }).toThrow(EXCEPTIONS.DEFINE_ROLE_EXCEPTION);
       });
 
       it('should not throw an exception on valid role name', function () {
@@ -141,10 +126,35 @@ describe('Service: Permission', function () {
         expect(angular.isFunction(CustomPermission.roleValidations.admin)).toBe(true);
       });
 
-      it('should not throw an exception on valid role name', function () {
-        Permission.defineManyRoles(['admin', 'publisher'], function () {});
-      });
     });
+
+    describe('#defineManyRoles (provider version)', function () {
+
+      it('should throw an exception on invalid role name', function () {
+          expect(function () {
+            Permission.defineManyRoles(123, function () {});
+          }).toThrow(EXCEPTIONS.DEFINE_MANY_ROLES_EXCEPTION)
+
+          expect(function () {
+            Permission.defineManyRoles(null, function () {});
+          }).toThrow(EXCEPTIONS.DEFINE_MANY_ROLES_EXCEPTION)
+
+          expect(function () {
+            Permission.defineManyRoles('admin', function () {});
+          }).toThrow(EXCEPTIONS.DEFINE_MANY_ROLES_EXCEPTION)
+
+          expect(function () {
+            Permission.defineManyRoles(['admin', 1], function () {});
+          }).toThrow(EXCEPTIONS.DEFINE_ROLE_EXCEPTION)
+      });
+
+      it('should not throw an exception on valid role name', function () {
+          Permission.defineManyRoles(['admin', 'publisher'], function () {});
+      });
+
+    });
+
+
   });
 
   describe('#defineRole', function () {
@@ -170,6 +180,7 @@ describe('Service: Permission', function () {
   });
 
   describe('#defineManyRoles', function () {
+
     it('should define many roles on run stage', function () {
      var systemRoles = ['admin', 'publisher', 'user', 'anonymous'];
      var userRoles = ['publisher', 'user'];
@@ -187,6 +198,7 @@ describe('Service: Permission', function () {
       expect(angular.isFunction(Permission.roleValidations.anonymous)).toBe(true);
 
     });
+
   });
 
   describe('#_validateRoleMap', function () {


### PR DESCRIPTION
When you have the same validation function for multiple roles you have to write a lot of the same code snippets in the defineRole function. 

Also I want my roles to defined automatically with data from the backend. I dont want to strongly type these. So i defined a new function called defineMany that takes a array of roles and in the validation callback injects the role name like this.

```javascript
Permission.defineMany(roles, function (stateParams, roleName) {
        return User.hasRole(roleName);
});
```
