### PR TITLE
Urgent fix: Defining roles is not working for instantiated service

### DIFF
--- a/src/permission.svc.js
+++ b/src/permission.svc.js
@@ -107,7 +107,7 @@
               scope where it is defined and therefore can interact with other modules
             **/
             validateRoleDefinitionParams(roleName, validationFunction);
-            roleValidationConfig[roleName] = validationFunction;
+            Permission.roleValidations[roleName] = validationFunction;
 
             return Permission;
           },


### PR DESCRIPTION
Methods `defineRole` and `defineManyRoles` are referencing `roleValidationConfig` that is passed to `Permission` service only at stage of instantiation. Reference to `roleValidations` has to be passed instead.