### PR TITLE
enable to set default permissions for states

### DIFF
--- a/src/permission.mdl.js
+++ b/src/permission.mdl.js
@@ -11,7 +11,7 @@
         }
 
         // If there are permissions set then prevent default and attempt to authorize
-        var permissions;
+        var permissions = Permission.defaultPermissions();
         if (toState.data && toState.data.permissions) {
           permissions = toState.data.permissions;
         } else if (toState.permissions) {

--- a/src/permission.svc.js
+++ b/src/permission.svc.js
@@ -3,6 +3,7 @@
 
   angular.module('permission')
     .provider('Permission', function () {
+      var defaultPermissions;
       var roleValidationConfig = {};
       var validateRoleDefinitionParams = function (roleName, validationFunction) {
         if (!angular.isString(roleName)) {
@@ -120,6 +121,13 @@
             }
 
             return definedPermissions;
+          },
+          defineDefaultPermissions: function (permissions) {
+            defaultPermissions = permissions;
+            return Permission;
+          },
+          defaultPermissions: function () {
+            return defaultPermissions;
           },
           resolveIfMatch: function (rolesArray, toParams) {
             var roles = angular.copy(rolesArray);


### PR DESCRIPTION
I was spraying the same permissions on a lot of state for that reason i did a way to set the default permissions than need only to set the different behavior

```js
  angular
    .module('fooModule', ['permission', 'user'])
    .run(function (Permission, User) {
      Permission
        .defineRole('anonymous', (stateParams) => !User)
        .defineRole('user', (stateParams) => User)
        .defineDefaultPermissions({
           only: ['user'],
           redirectTo: 'login'
        })
    });
```

then 

```js
$stateProvider
    .state('user', {
      url: '/user'
    })
    .state('login', {
      url: '/login',
      data: {
        permissions: {
          only: ['anonymous'],
          redirectTo: 'user'
      }
    })
```

So the `/user` uses the default permissions and the `/login` override the default permissions
