### PR TITLE
Add redirectTo syntax similar to  ui-sref

### DIFF
--- a/src/core/permissionModule.js
+++ b/src/core/permissionModule.js
@@ -114,8 +114,8 @@
 
             return permissions
               .resolveRedirectState(rejectedPermission)
-              .then(function (redirectStateName) {
-                $state.go(redirectStateName, toParams);
+              .then(function (sref) {
+                $state.go(sref.to, sref.params || toParams, sref.options);
               });
           })
           .finally(function () {

--- a/src/models/PermissionMap.js
+++ b/src/models/PermissionMap.js
@@ -51,7 +51,7 @@
         }
 
         if (angular.isString(this.redirectTo)) {
-          return $q.resolve(this.redirectTo);
+          return $q.resolve({ to: this.redirectTo, params: null, options: null });
         }
 
         // If redirectTo state is not defined stay where you are
@@ -73,7 +73,7 @@
             if (!angular.isString(redirectState)) {
               throw new TypeError('When used "redirectTo" as function, returned value must be string with state name');
             }
-            return redirectState;
+            return { to: redirectState, params: null, options: null };
           });
       }
 
@@ -101,7 +101,7 @@
         }
 
         if (angular.isString(redirectState)) {
-          return $q.resolve(redirectState);
+          return $q.resolve({ to: redirectState, params: null, options: null });
         }
       }
 

--- a/src/models/PermissionMap.js
+++ b/src/models/PermissionMap.js
@@ -3,7 +3,7 @@
 
   angular
     .module('permission')
-    .factory('PermissionMap', function ($q) {
+    .factory('PermissionMap', function ($q, $parse) {
 
       /**
        * Constructs map object instructing authorization service how to handle authorizing
@@ -51,7 +51,7 @@
         }
 
         if (angular.isString(this.redirectTo)) {
-          return $q.resolve({ to: this.redirectTo, params: null, options: null });
+          return $q.resolve(parseStateRef(this.redirectTo));
         }
 
         // If redirectTo state is not defined stay where you are
@@ -73,7 +73,7 @@
             if (!angular.isString(redirectState)) {
               throw new TypeError('When used "redirectTo" as function, returned value must be string with state name');
             }
-            return { to: redirectState, params: null, options: null };
+            return parseStateRef(redirectState);
           });
       }
 
@@ -101,9 +101,40 @@
         }
 
         if (angular.isString(redirectState)) {
-          return $q.resolve({ to: redirectState, params: null, options: null });
+          return $q.resolve(parseStateRef(redirectState));
         }
       }
+
+      /**
+       * Parse a stateRef expression like in ui-sref directive. The state is mandatory but stateParameters are optional.
+       * @private
+       *
+       * @param sref
+       * @returns {{to: String, params: (Object|null), options: (Object| null)}}
+       */
+      function parseStateRef(sref) {
+        var parsed = sref.replace(/\n/g, ' ').match(/^([^(]+?)\s*(\((.*)\))?$/);
+        if (!parsed || parsed.length !== 4){
+          throw new SyntaxError('Invalid state ref \'' + sref + '\'');
+        }
+
+        var params = null;
+        if(parsed[3]) {
+          try {
+            var getter = $parse(parsed[3]);
+            params = getter();
+          } catch(e) {
+            throw new SyntaxError('Failed to parse state parameters');
+          }
+        }
+
+        if(params !== null && !angular.isObject(params)) {
+          throw new TypeError('State parameters must be an object');
+        }
+
+        return { to: parsed[1], params: params || null, options: null };
+      }
+
 
       /**
        * Handles extraction of permission map "only" and "except" properties

--- a/test/models/PermissionMap/redirectToParam.test.js
+++ b/test/models/PermissionMap/redirectToParam.test.js
@@ -73,6 +73,29 @@ describe('model: PermissionMap', function () {
         // THEN
         expect($state.current.name).toBe('redirected');
       });
+
+      it('should redirect based on state name and parameters present in "redirectTo"', function () {
+        // GIVEN
+        $stateProvider
+          .state('redirected', {
+            url:'/?redirectionParam'
+          })
+          .state('redirect', {
+            data: {
+              permissions: {
+                only: ['denied'],
+                redirectTo: 'redirected({ redirectionParam: "here"})'
+              }
+            }
+          });
+
+        // WHEN
+        $state.go('redirect');
+        $rootScope.$apply();
+
+        expect($state.current.name).toBe('redirected');
+        expect($state.params.redirectionParam).toBe('here');
+      });
     });
 
     describe('used as object', function () {


### PR DESCRIPTION
It is now possible to write something like:

redirectTo : 'my-state({ parameter: "value"})'

This new feature benefits string, object and function redirection. The regular
expression used to parse the string is the same that the one found in ui-sref.
To parse the parameter I use angular's $parse service.

I added one unit test to test that parameters are available in the state after
the redirection.

Note: It seems that ui-router filters parameters that are not declared the url
part of the state declaration