### PR TITLE
Add isolate scope to permission directive.

### DIFF
--- a/src/core/permissionDirective.js
+++ b/src/core/permissionDirective.js
@@ -14,6 +14,7 @@
     .directive('permission', function ($log, Authorization, PermissionMap) {
       return {
         restrict: 'A',
+        scope: true,
         bindToController: {
           only: '=',
           except: '='


### PR DESCRIPTION
I've noticed that the directive won't work properly unless an isolate scope is setup. I believe this has to do with the way `bindToController` works with isolated scopes.  I was trying to use this directive in a local project and while the ui-router hooks work great the directive does not seem to respond. Debugging this it looked like `permissions.only` and `permissions.except` where always empty (i.e. they did not get properly bound to the controller).

Though the documentation is unclear, it looks like `bindToController` does not work unless the directive is creating a new scope (either through `scope: {}` or `scope: true`). 

The lack of scope definition seemed to imply that the original intent is to bind the directive to the parent $scope. Rather than creating a true isolate scope, this PR inherits from the parent scope keeping more in line with what I believe is the original intent. As an aside, it seems that creating a true isolate scope `scope: {}` would still work fine for this directive.