### PR TITLE
Add optional notify param. Default to false

### DIFF
--- a/dist/angular-permission.js
+++ b/dist/angular-permission.js
@@ -1,7 +1,7 @@
 /**
  * angular-permission
  * Route permission and access control as simple as it can get
- * @version v2.1.1 - 2016-03-02
+ * @version v2.1.1 - 2016-03-04
  * @link http://www.rafaelvidaurre.com
  * @author Rafael Vidaurre <narzerus@gmail.com>
  * @license MIT License, http://www.opensource.org/licenses/MIT
@@ -123,7 +123,7 @@
 
             return permissions.resolveRedirectState(rejectedPermission)
               .then(function (redirectStateName) {
-                $state.go(redirectStateName, toParams, {notify: false});
+                $state.go(redirectStateName, toParams, {notify: toState.data.permissions.notify || false});
               })
               .then(function () {
                 $rootScope.$broadcast('$stateChangeSuccess', toState, toParams, options);


### PR DESCRIPTION
This commit is in response to my issue #169 

By default, angular-permission sets `{notify: false}`, so when the a permission is denied and `redirectTo` is present, `$state.go(...)` is called to transition to the state but with `{notify: false}` I only get a changed URL with no page loaded. It seems some others are having this issue as well.

This commit keeps the default false value but provides an optional true value for someone like me having an issue.