### PR TITLE
* Fixed attributes processing in permission directive.

### DIFF
--- a/src/core/permissionDirective.js
+++ b/src/core/permissionDirective.js
@@ -20,7 +20,7 @@
           except: '='
         },
         controllerAs: 'permission',
-        controller: function ($scope, $element) {
+        controller: function ($scope, $element, $attrs) {
           var permission = this;
 
           $scope.$watchGroup(['permission.only', 'permission.except'],
@@ -28,8 +28,8 @@
               try {
                 Authorization
                   .authorize(new PermissionMap({
-                    only: permission.only,
-                    except: permission.except
+                    only: $scope.$eval($attrs.only),
+                    except: $scope.$eval($attrs.except)
                   }), null)
                   .then(function () {
                     $element.removeClass('ng-hide');

--- a/src/core/permissionDirective.js
+++ b/src/core/permissionDirective.js
@@ -21,8 +21,6 @@
         },
         controllerAs: 'permission',
         controller: function ($scope, $element, $attrs) {
-          var permission = this;
-
           $scope.$watchGroup(['permission.only', 'permission.except'],
             function () {
               try {


### PR DESCRIPTION
In case where you use 
```js
.authorize(new PermissionMap({
    only: permission.only,
    except: permission.except
})
```
_permission.only_ and _permission.except_ is undefined. This fix it and correctly retrieve values from _only_ and _except_ attributes.