### PR TITLE
$scope.transition needs to be anything but null during the first iteration of $stateChangeStart

### DIFF
--- a/src/permission-ui/permission-ui.js
+++ b/src/permission-ui/permission-ui.js
@@ -50,6 +50,7 @@ function run($rootScope, $state, PermTransitionProperties, PermTransitionEvents,
       if (!PermTransitionEvents.areEventsDefaultPrevented()) {
         PermTransitionEvents.broadcastPermissionStartEvent();
 
+        $state.transition = {};
         event.preventDefault();
         var statePermissionMap = new PermStatePermissionMap(PermTransitionProperties.toState);
 


### PR DESCRIPTION
First, this is tightly coupled to #297 _$stateChangeStart event triggered twice_ and will probably be corrected in ui-router v.1.0.0. This solves my issue #322 _Angular Permission module breaks the browser forward and back history buttons._

The function `$state.transitionTo`, which is syntactic sugar for `$state.go`, is called twice. The first time `options.notify` is true which means` $stateChangeStart` event is fired. Angular permission module hijacks it and does it magic. The first thing Angular permission does is cancel the original transition. Note, the transition will handle itself gracefully if the event listener for `$stateChangeState` makes a state change using `$state.go` synchronously. If it is async there is race condition between the two `transtions` to resolve first. That is why `event.preventDefault()` is needed. When `$state.transitionTo` is called the second time after Angular permisssion resolves everything, `options.notify` is set to false. This triggers a single line of code in ui-router which screws everything up with the browser history by doing weird things with `$window.location` in the deeper parts of Angular base.

````
if ($state.transition == null) $urlRouter.update();
`````

Found in:
````
      // Broadcast start event and cancel the transition if requested
      if (options.notify) {
        /**
         * @ngdoc event
         * @name ui.router.state.$state#$stateChangeStart
         * @eventOf ui.router.state.$state
         * @eventType broadcast on root scope
         * @description
         * Fired when the state transition **begins**. You can use `event.preventDefault()`
         * to prevent the transition from happening and then the transition promise will be
         * rejected with a `'transition prevented'` value.
         *
         * @param {Object} event Event object.
         * @param {State} toState The state being transitioned to.
         * @param {Object} toParams The params supplied to the `toState`.
         * @param {State} fromState The current state, pre-transition.
         * @param {Object} fromParams The params supplied to the `fromState`.
         *
         * @example
         *
         * <pre>
         * $rootScope.$on('$stateChangeStart',
         * function(event, toState, toParams, fromState, fromParams){
         *     event.preventDefault();
         *     // transitionTo() promise will be rejected with
         *     // a 'transition prevented' error
         * })
         * </pre>
         */
        if ($rootScope.$broadcast('$stateChangeStart', to.self, toParams, from.self, fromParams, options).defaultPrevented) {
          $rootScope.$broadcast('$stateChangeCancel', to.self, toParams, from.self, fromParams);
          //Don't update and resync url if there's been a new transition started. see issue #2238, #600
          if ($state.transition == null) $urlRouter.update();
          return TransitionPrevented;
        }
      }
````

My problem is that it does "update and resync url if there's been a new transition started" `$urlRouter.location` here doesn't matter because the second call to `$state.transitionTo` will set `transition` and `$state.transition` to an unresolved promise again immediately after that code is executed. That promise will call `$urlRouter.update()` whether it is resolved or rejected.

````
var transition = $state.transition = resolved.then(function () { ... })
````

$urlRouter.update() was called once and then again when it should only be called once.  I tested it and it worked.