### PR TITLE
Ensure parent permissions are evaluated only once

### DIFF
--- a/src/permission-ui/authorization/StatePermissionMap.js
+++ b/src/permission-ui/authorization/StatePermissionMap.js
@@ -56,7 +56,8 @@ function PermStatePermissionMap(PermPermissionMap) {
    */
   function areSetStatePermissions(state) {
     try {
-      return !!state.data.permissions;
+      // We check for hasOwnProperty here because ui-router lets the `data` property inherit from its parent
+      return Object.prototype.hasOwnProperty.call(state.data, 'permissions') && !!state.data.permissions;
     } catch (e) {
       return false;
     }

--- a/test/unit/permission-ui/authorization/StatePermissionMap.test.js
+++ b/test/unit/permission-ui/authorization/StatePermissionMap.test.js
@@ -21,10 +21,14 @@ describe('permission.ui', function () {
           // GIVEN
           var state = jasmine.createSpyObj('state', ['$$permissionState']);
           state.$$permissionState.and.callFake(function () {
+            var parent = {permissions: {only: ['accepted'], except: ['denied']}};
+            var child = Object.create(parent);
+            child.permissions = {only: ['acceptedChild'], except: ['deniedChild']};
+
             return {
               path: [
-                {data: {permissions: {only: ['accepted'], except: ['denied']}}},
-                {data: {permissions: {only: ['acceptedChild'], except: ['deniedChild']}}}
+                {data: child},
+                {data: parent}
               ]
             };
           });
@@ -33,8 +37,38 @@ describe('permission.ui', function () {
           var map = new PermStatePermissionMap(state);
 
           // THEN
-          expect(map.only).toEqual([['accepted'], ['acceptedChild']]);
-          expect(map.except).toEqual([['denied'], ['deniedChild']]);
+          expect(map.only).toEqual([['acceptedChild'], ['accepted']]);
+          expect(map.except).toEqual([['deniedChild'], ['denied']]);
+          expect(map.redirectTo).not.toBeDefined();
+        });
+
+        it('should not duplicate parent state inheritance if childs dont have permissions', function () {
+          // GIVEN
+          var state = jasmine.createSpyObj('state', ['$$permissionState']);
+          state.$$permissionState.and.callFake(function () {
+            var grandparent = {permissions: {only: ['accepted'], except: ['denied']}};
+            var parent = Object.create(grandparent);
+            parent.permissions = {
+              only: ['acceptedChild'],
+              except: ['deniedChild']
+            };
+            var child = Object.create(parent);
+
+            return {
+              path: [
+                {data: child},
+                {data: parent},
+                {data: grandparent}
+              ]
+            };
+          });
+
+          // WHEN
+          var map = new PermStatePermissionMap(state);
+
+          // THEN
+          expect(map.only).toEqual([['acceptedChild'], ['accepted']]);
+          expect(map.except).toEqual([['deniedChild'], ['denied']]);
           expect(map.redirectTo).not.toBeDefined();
         });
       });


### PR DESCRIPTION
This fixes Goal 1 marked #338. 

The issue was, that if I had a state hierarchy like, 

```
$stateProvider
  .state('root', {
    ...
    data: {
      permissions: {
        only: 'isLoggedIn'
      }
    }
  })
  .state('root.child', {
    ...
  });
```

then, upon $state.go('root'), the `isLoggedIn` permission would evaluate twice, once for the parent and once for the child. 

This was due to UI-Router making the `data` property of states prototypically inherit from their parent. Thus if a child does not specify its own `permissions` property, then it would use its parent property. 

This was easily fixed by making sure we would only use the permissions from a state that `hasOwnProperty('permissions')`