### PR TITLE
Fix redirect injection

### DIFF
--- a/src/permission/authorization/PermissionMap.js
+++ b/src/permission/authorization/PermissionMap.js
@@ -284,7 +284,7 @@ function PermPermissionMap($q, $log, $injector, PermTransitionProperties, PermRo
    * @returns {boolean}
    */
   function isInjectable(property) {
-    return angular.isArray(property) || angular.isArray(property.$inject);
+    return property && (angular.isArray(property) || angular.isArray(property.$inject));
   }
 
   /**

--- a/src/permission/authorization/PermissionMap.js
+++ b/src/permission/authorization/PermissionMap.js
@@ -155,6 +155,10 @@ function PermPermissionMap($q, $log, $injector, PermTransitionProperties, PermRo
       return normalizeStringRedirectionRule(redirectTo);
     }
 
+    if (isInjectable(redirectTo) || angular.isFunction(redirectTo)) {
+      return normalizeFunctionRedirectionRule(redirectTo);
+    }
+
     if (angular.isObject(redirectTo)) {
       if (isObjectSingleRedirectionRule(redirectTo)) {
         return normalizeObjectSingleRedirectionRule(redirectTo);
@@ -165,10 +169,6 @@ function PermPermissionMap($q, $log, $injector, PermTransitionProperties, PermRo
       }
 
       throw new ReferenceError('When used "redirectTo" as object, property "default" must be defined');
-    }
-
-    if (angular.isFunction(redirectTo)) {
-      return normalizeFunctionRedirectionRule(redirectTo);
     }
 
     return redirectTo;
@@ -189,7 +189,6 @@ function PermPermissionMap($q, $log, $injector, PermTransitionProperties, PermRo
     redirectionMap.default = function () {
       return {state: redirectTo};
     };
-    redirectionMap.default.$inject = ['rejectedPermission', 'transitionProperties'];
 
     return redirectionMap;
   }
@@ -222,7 +221,6 @@ function PermPermissionMap($q, $log, $injector, PermTransitionProperties, PermRo
     redirectionMap.default = function () {
       return redirectTo;
     };
-    redirectionMap.default.$inject = ['rejectedPermission', 'transitionProperties'];
 
     return redirectionMap;
   }
@@ -255,9 +253,7 @@ function PermPermissionMap($q, $log, $injector, PermTransitionProperties, PermRo
     angular.forEach(redirectTo, function (redirection, permission) {
       if (isInjectable(redirection)) {
         redirectionMap[permission] = redirection;
-      }
-
-      if (angular.isFunction(redirection)) {
+      } else if (angular.isFunction(redirection)) {
         redirectionMap[permission] = redirection;
         redirectionMap[permission].$inject = ['rejectedPermission', 'transitionProperties'];
       }
@@ -266,14 +262,12 @@ function PermPermissionMap($q, $log, $injector, PermTransitionProperties, PermRo
         redirectionMap[permission] = function () {
           return redirection;
         };
-        redirectionMap[permission].$inject = ['rejectedPermission', 'transitionProperties'];
       }
 
       if (angular.isString(redirection)) {
         redirectionMap[permission] = function () {
           return {state: redirection};
         };
-        redirectionMap[permission].$inject = ['rejectedPermission', 'transitionProperties'];
       }
     });
 
@@ -298,7 +292,7 @@ function PermPermissionMap($q, $log, $injector, PermTransitionProperties, PermRo
    * @methodOf permission.PermissionMap
    * @private
    *
-   * @param redirectTo {Function} PermPermission map property "redirectTo"
+   * @param redirectTo {Function|Array} PermPermission map property "redirectTo"
    *
    * @returns {Object<String, Object>} Redirection dictionary object
    */
@@ -306,8 +300,12 @@ function PermPermissionMap($q, $log, $injector, PermTransitionProperties, PermRo
     var redirectionMap = {};
 
     redirectionMap.default = redirectTo;
-    redirectionMap.default.$inject = ['rejectedPermission', 'transitionProperties'];
 
+    if (!isInjectable(redirectTo)) {
+      // Provide backwards compatibility with non-injected redirect
+      redirectionMap.default.$inject = ['rejectedPermission', 'transitionProperties'];
+    }
+    
     return redirectionMap;
   }
 

--- a/src/permission/authorization/PermissionMap.js
+++ b/src/permission/authorization/PermissionMap.js
@@ -256,15 +256,11 @@ function PermPermissionMap($q, $log, $injector, PermTransitionProperties, PermRo
       } else if (angular.isFunction(redirection)) {
         redirectionMap[permission] = redirection;
         redirectionMap[permission].$inject = ['rejectedPermission', 'transitionProperties'];
-      }
-
-      if (angular.isObject(redirection)) {
+      } else if (angular.isObject(redirection)) {
         redirectionMap[permission] = function () {
           return redirection;
         };
-      }
-
-      if (angular.isString(redirection)) {
+      } else if (angular.isString(redirection)) {
         redirectionMap[permission] = function () {
           return {state: redirection};
         };

--- a/test/unit/permission/authorization/PermissionMap.test.js
+++ b/test/unit/permission/authorization/PermissionMap.test.js
@@ -127,7 +127,7 @@ describe('permission', function () {
           // THEN
           expect(redirectStateName).toBePromise();
           expect(redirectStateName).toBeResolvedWith({state: 'adminRedirect'});
-          expect(adminRedirectTo).toHaveBeenCalledWith('ADMIN', jasmine.any(Object));
+          expect(adminRedirectTo).toHaveBeenCalledWith(PermRoleStore, 'ADMIN');
         });
 
         it('should return resolved promise of redirectTo value when passed as object with function value property', function () {
@@ -218,7 +218,7 @@ describe('permission', function () {
           // THEN
           expect(redirectStateName).toBePromise();
           expect(redirectStateName).toBeResolvedWith({state: 'redirectStateName'});
-          expect(redirectToFunction).toHaveBeenCalledWith('unauthorizedPermission', jasmine.any(Object));
+          expect(redirectToFunction).toHaveBeenCalledWith(jasmine.any(Object), PermPermissionMap, 'unauthorizedPermission');
         });
 
         it('should return resolved promise of redirectTo value when passed as function returning string', function () {


### PR DESCRIPTION
Currently after v5.x, redirectTo custom injection is broken. It was due to overridden $inject property. 

Also, I removed the extraneous $inject properties used on the wrapped functions as I saw them as unneeded. I don't have a huge preference though if you really want them