### PR TITLE
Restrategize transition intercept

### DIFF
--- a/src/permission-ui/authorization/StateAuthorization.js
+++ b/src/permission-ui/authorization/StateAuthorization.js
@@ -6,14 +6,13 @@
  * @name permission.ui.PermStateAuthorization
  *
  * @param $q {Object} Angular promise implementation
- * @param $state {Object} State object
  * @param PermStatePermissionMap {permission.ui.PermStatePermissionMap|Function} Angular promise implementation
  */
-function PermStateAuthorization($q, $state, PermStatePermissionMap) {
+function PermStateAuthorization($q, PermStatePermissionMap) {
   'ngInject';
 
   this.authorizeByPermissionMap = authorizeByPermissionMap;
-  this.authorizeByStateName = authorizeByStateName;
+  this.authorizeByState = authorizeByState;
 
   /**
    * Handles authorization based on provided state permission map
@@ -28,15 +27,14 @@ function PermStateAuthorization($q, $state, PermStatePermissionMap) {
   }
 
   /**
-   * Authorizes uses by provided state name
+   * Authorizes uses by provided state definition
    * @methodOf permission.ui.PermStateAuthorization
    *
-   * @param stateName {String}
+   * @param state {Object}
    * @returns {promise}
    */
-  function authorizeByStateName(stateName) {
-    var srefState = $state.get(stateName);
-    var permissionMap = new PermStatePermissionMap(srefState);
+  function authorizeByState(state) {
+    var permissionMap = new PermStatePermissionMap(state);
 
     return authorizeByPermissionMap(permissionMap);
   }

--- a/src/permission-ui/permission-ui.js
+++ b/src/permission-ui/permission-ui.js
@@ -28,45 +28,63 @@ function config($stateProvider) {
 }
 
 /**
+ * @param $delegate {Object} The $state decorator delegate
+ * @param $q {Object}
  * @param $rootScope {Object}
- * @param $state {Object}
  * @param PermTransitionProperties {permission.PermTransitionProperties}
  * @param PermTransitionEvents {permission.ui.PermTransitionEvents}
  * @param PermStateAuthorization {permission.ui.PermStateAuthorization}
  * @param PermStatePermissionMap {permission.ui.PermStatePermissionMap}
  */
-function run($rootScope, $state, PermTransitionProperties, PermTransitionEvents, PermStateAuthorization, PermStatePermissionMap) {
+function state($delegate, $q, $rootScope, PermTransitionProperties, PermTransitionEvents, PermStateAuthorization, PermStatePermissionMap) {
   'ngInject';
 
-  /**
-   * State transition interceptor
-   */
-  $rootScope.$on('$stateChangeStart', function (event, toState, toParams, fromState, fromParams, options) {
+  var $state = $delegate;
+  // Expose only for testing purposes
+  $state.$$transitionTo = $state.transitionTo;
 
-    if (!isAuthorizationFinished()) {
-      setStateAuthorizationStatus(true);
-      setTransitionProperties();
+  $state.transitionTo = function(to, toParams, options) {
+    // Similar param normalization as in $state.transitionTo
+    toParams = toParams || {};
+    options = angular.extend({
+      location: true, inherit: false, relative: null, notify: true, reload: false, $retry: false
+    }, options || {});
+    var toState, fromState = $state.current, fromParams = $state.params;
+    var name = angular.isString(to) ? to : to.name;
 
-      if (!PermTransitionEvents.areEventsDefaultPrevented()) {
-        PermTransitionEvents.broadcastPermissionStartEvent();
+    if (!options.relative && isRelative(name)) {
+      throw new Error('No reference point given for path \''  + name + '\'');
+    }
 
-        event.preventDefault();
-        var statePermissionMap = new PermStatePermissionMap(PermTransitionProperties.toState);
+    toState = $state.get(name, options.relative);
 
-        PermStateAuthorization
-          .authorizeByPermissionMap(statePermissionMap)
-          .then(function () {
-            handleAuthorizedState();
-          })
-          .catch(function (rejectedPermission) {
-            handleUnauthorizedState(rejectedPermission, statePermissionMap);
-          })
-          .finally(function () {
-            setStateAuthorizationStatus(false);
-          });
-      } else {
-        setStateAuthorizationStatus(false);
-      }
+    if (!toState) {
+      throw new Error('Unfound state \'' + name + '\'');
+    }
+
+    setTransitionProperties();
+
+    // Maintain UI-Router behavior when $stateChangeStart or $stateChangePermissionStart is cancelled
+    if (PermTransitionEvents.areEventsDefaultPrevented()) {
+      return delegateTransitionTo();
+    }
+    
+    var statePermissionMap = new PermStatePermissionMap(PermTransitionProperties.toState);
+
+    return PermStateAuthorization
+      .authorizeByPermissionMap(statePermissionMap)
+      .then(handleAuthorizedState, handleUnauthorizedState(statePermissionMap));
+
+    /**
+     * True if the stateName is a relative name, to an parent state
+     * @method
+     * @private
+
+     * @param status {string} Name of state
+     * @returns {boolean}
+     */
+    function isRelative(stateName) {
+      return stateName.indexOf('.') === 0 || stateName.indexOf('^') === 0;
     }
 
     /**
@@ -83,25 +101,15 @@ function run($rootScope, $state, PermTransitionProperties, PermTransitionEvents,
     }
 
     /**
-     * Sets internal state `$$finishedAuthorization` variable to prevent looping
+     * Performs $state.transitionTo with parameters
      * @method
      * @private
-     *
-     * @param status {boolean} When true authorization has been already preceded
+     * 
+     * @returns {Promise}
      */
-    function setStateAuthorizationStatus(status) {
-      angular.extend(toState, {'$$isAuthorizationFinished': status});
-    }
-
-    /**
-     * Checks if state has been already checked for authorization
-     * @method
-     * @private
-     *
-     * @returns {boolean}
-     */
-    function isAuthorizationFinished() {
-      return toState.$$isAuthorizationFinished;
+    function delegateTransitionTo() {
+      return $state.$$transitionTo(PermTransitionProperties.toState.name, 
+        PermTransitionProperties.toParams, PermTransitionProperties.options);
     }
 
     /**
@@ -112,14 +120,7 @@ function run($rootScope, $state, PermTransitionProperties, PermTransitionEvents,
     function handleAuthorizedState() {
       PermTransitionEvents.broadcastPermissionAcceptedEvent();
 
-      // Overwrite notify option to broadcast it later
-      var transitionOptions = angular.extend({}, PermTransitionProperties.options, {notify: false, location: true});
-
-      $state
-        .go(PermTransitionProperties.toState.name, PermTransitionProperties.toParams, transitionOptions)
-        .then(function () {
-          PermTransitionEvents.broadcastStateChangeSuccessEvent();
-        });
+      return delegateTransitionTo();
     }
 
     /**
@@ -127,25 +128,29 @@ function run($rootScope, $state, PermTransitionProperties, PermTransitionEvents,
      * @method
      * @private
      *
-     * @param rejectedPermission {String} Rejected access right
      * @param statePermissionMap {permission.ui.PermPermissionMap} State permission map
+     * @returns {Function} A function that accepts the rejectedPermission access right
      */
-    function handleUnauthorizedState(rejectedPermission, statePermissionMap) {
-      PermTransitionEvents.broadcastPermissionDeniedEvent();
+    function handleUnauthorizedState(statePermissionMap) {
+      return function(rejectedPermission) {
+        PermTransitionEvents.broadcastPermissionDeniedEvent();
 
-      statePermissionMap
-        .resolveRedirectState(rejectedPermission)
-        .then(function (redirect) {
-          $state.go(redirect.state, redirect.params, redirect.options);
-        });
+        return statePermissionMap
+          .resolveRedirectState(rejectedPermission)
+          .then(function (redirect) {
+            return $state.go(redirect.state, redirect.params, redirect.options);
+          });
+      };
     }
-  });
+  };
+
+  return $state;
 }
 
 var uiPermission = angular
   .module('permission.ui', ['permission', 'ui.router'])
   .config(config)
-  .run(run);
+  .decorator('$state', state);
 
 if (typeof module !== 'undefined' && typeof exports !== 'undefined' && module.exports === exports) {
   module.exports = uiPermission.name;

--- a/src/permission-ui/permission-ui.js
+++ b/src/permission-ui/permission-ui.js
@@ -64,8 +64,13 @@ function state($delegate, $q, $rootScope, PermTransitionProperties, PermTransiti
 
     setTransitionProperties();
 
-    // Maintain UI-Router behavior when $stateChangeStart or $stateChangePermissionStart is cancelled
-    if (PermTransitionEvents.areEventsDefaultPrevented()) {
+    // Maintain UI-Router behavior when $stateChangeStart is cancelled
+    if (PermTransitionEvents.isStateChangeStartDefaultPrevented()) {
+      return $q.reject(new Error('transition cancelled'));
+    }
+
+    // Delegate directly to UI-Router when $stateChangePermissionStart is cancelled
+    if (PermTransitionEvents.isStateChangePermissionStartDefaultPrevented()) {
       return delegateTransitionTo();
     }
     

--- a/src/permission-ui/transition/TransitionEvents.js
+++ b/src/permission-ui/transition/TransitionEvents.js
@@ -15,7 +15,6 @@ function PermTransitionEvents($delegate, $rootScope, PermTransitionProperties, P
   'ngInject';
 
   $delegate.areEventsDefaultPrevented = areEventsDefaultPrevented;
-  $delegate.broadcastStateChangeSuccessEvent = broadcastStateChangeSuccessEvent;
   $delegate.broadcastPermissionStartEvent = broadcastPermissionStartEvent;
   $delegate.broadcastPermissionAcceptedEvent = broadcastPermissionAcceptedEvent;
   $delegate.broadcastPermissionDeniedEvent = broadcastPermissionDeniedEvent;
@@ -58,16 +57,6 @@ function PermTransitionEvents($delegate, $rootScope, PermTransitionProperties, P
     $rootScope.$broadcast(PermTransitionEventNames.permissionDenies,
       PermTransitionProperties.toState, PermTransitionProperties.toParams,
       PermTransitionProperties.options);
-  }
-
-  /**
-   * Broadcasts "$stateChangeSuccess" event from $rootScope
-   * @methodOf permission.ui.PermTransitionEvents
-   */
-  function broadcastStateChangeSuccessEvent() {
-    $rootScope.$broadcast('$stateChangeSuccess',
-      PermTransitionProperties.toState, PermTransitionProperties.toParams,
-      PermTransitionProperties.fromState, PermTransitionProperties.fromParams);
   }
 
   /**

--- a/src/permission-ui/transition/TransitionEvents.js
+++ b/src/permission-ui/transition/TransitionEvents.js
@@ -14,20 +14,11 @@
 function PermTransitionEvents($delegate, $rootScope, PermTransitionProperties, PermTransitionEventNames) {
   'ngInject';
 
-  $delegate.areEventsDefaultPrevented = areEventsDefaultPrevented;
+  $delegate.isStateChangeStartDefaultPrevented = isStateChangeStartDefaultPrevented;
+  $delegate.isStateChangePermissionStartDefaultPrevented = isStateChangePermissionStartDefaultPrevented;
   $delegate.broadcastPermissionStartEvent = broadcastPermissionStartEvent;
   $delegate.broadcastPermissionAcceptedEvent = broadcastPermissionAcceptedEvent;
   $delegate.broadcastPermissionDeniedEvent = broadcastPermissionDeniedEvent;
-
-  /**
-   * Checks if state events are not prevented by default
-   * @methodOf permission.ui.PermTransitionEvents
-   *
-   * @returns {boolean}
-   */
-  function areEventsDefaultPrevented() {
-    return isStateChangePermissionStartDefaultPrevented() || isStateChangeStartDefaultPrevented();
-  }
 
   /**
    * Broadcasts "$stateChangePermissionStart" event from $rootScope
@@ -62,7 +53,6 @@ function PermTransitionEvents($delegate, $rootScope, PermTransitionProperties, P
   /**
    * Checks if event $stateChangePermissionStart hasn't been disabled by default
    * @methodOf permission.ui.PermTransitionEvents
-   * @private
    *
    * @returns {boolean}
    */
@@ -75,7 +65,6 @@ function PermTransitionEvents($delegate, $rootScope, PermTransitionProperties, P
   /**
    * Checks if event $stateChangeStart hasn't been disabled by default
    * @methodOf permission.ui.PermTransitionEvents
-   * @private
    *
    * @returns {boolean}
    */

--- a/src/permission/directives/permission.js
+++ b/src/permission/directives/permission.js
@@ -72,9 +72,10 @@ function PermissionDirective($log, $injector, PermPermissionMap, PermPermissionS
           try {
             if (isSrefStateDefined()) {
               var PermStateAuthorization = $injector.get('PermStateAuthorization');
+              var $state = $injector.get('$state');
 
               PermStateAuthorization
-                .authorizeByStateName(permission.sref)
+                .authorizeByState($state.get(permission.sref))
                 .then(function () {
                   onAuthorizedAccess();
                 })

--- a/test/unit/permission-ui/permission-ui.test.js
+++ b/test/unit/permission-ui/permission-ui.test.js
@@ -70,7 +70,6 @@ describe('permission.ui', function () {
         // WHEN
         // THEN
         expect($state.current.$$permissionState).toBeDefined();
-        expect($state.current.$$isAuthorizationFinished).toBeDefined();
       });
     });
 
@@ -154,7 +153,7 @@ describe('permission.ui', function () {
 
         it('should honor params and options passed to "transitionTo" or "go" function', function () {
           // GIVEN
-          spyOn($state, 'go').and.callThrough();
+          spyOn($state, '$$transitionTo').and.callThrough();
 
           $stateProvider
             .state('acceptedWithParamsAndOptions', {
@@ -169,12 +168,12 @@ describe('permission.ui', function () {
             });
 
           // WHEN
-          $state.go('acceptedWithParamsAndOptions', {param: 'param'}, {relative: true});
+          $state.go('acceptedWithParamsAndOptions', {param: 'param'}, {relative: true, location: false});
           $rootScope.$apply();
 
           // THEN
-          expect($state.go).toHaveBeenCalledWith('acceptedWithParamsAndOptions', {param: 'param'}, {
-            location: true, inherit: true, relative: true, notify: false, reload: false, $retry: false
+          expect($state.$$transitionTo).toHaveBeenCalledWith('acceptedWithParamsAndOptions', {param: 'param'}, {
+            location: false, inherit: true, relative: true, notify: true, reload: false, $retry: false
           });
         });
       });

--- a/test/unit/permission-ui/transition/TransitionEvents.test.js
+++ b/test/unit/permission-ui/transition/TransitionEvents.test.js
@@ -63,24 +63,36 @@ describe('permission.ui', function () {
         });
       });
 
-      describe('method: areEventsDefaultPrevented', function () {
-        it('should check if none of events prevents authorization', function () {
+      describe('method: isStateChangeStartDefaultPrevented', function () {
+        it('should check if $stateChangeStart event prevents authorization', function () {
           // GIVEN
           spyOn($rootScope, '$broadcast').and.callThrough();
-          PermTransitionProperties.toState = {
-            $$isAuthorizationFinished: true
-          };
+          PermTransitionProperties.toState = {};
+
+          // WHE
+          var result = PermTransitionEvents.isStateChangeStartDefaultPrevented();
+
+          // THEN
+          expect($rootScope.$broadcast).toHaveBeenCalledWith('$stateChangeStart',
+            jasmine.any(Object), jasmine.any(Object), jasmine.any(Object), jasmine.any(Object), jasmine.any(Object)
+          );
+
+          expect(result).toEqual(jasmine.any(Boolean));
+        });
+      });
+
+      describe('method: isStateChangePermissionStartDefaultPrevented', function () {
+        it('should check if $stateChangePermissionStart event prevents authorization', function () {
+          // GIVEN
+          spyOn($rootScope, '$broadcast').and.callThrough();
+          PermTransitionProperties.toState = {};
 
           // WHEN
-          var result = PermTransitionEvents.areEventsDefaultPrevented();
+          var result = PermTransitionEvents.isStateChangePermissionStartDefaultPrevented();
 
           // THEN
           expect($rootScope.$broadcast).toHaveBeenCalledWith('$stateChangePermissionStart',
             jasmine.any(Object), jasmine.any(Object), jasmine.any(Object)
-          );
-
-          expect($rootScope.$broadcast).toHaveBeenCalledWith('$stateChangeStart',
-            jasmine.any(Object), jasmine.any(Object), jasmine.any(Object), jasmine.any(Object), jasmine.any(Object)
           );
 
           expect(result).toEqual(jasmine.any(Boolean));

--- a/test/unit/permission-ui/transition/TransitionEvents.test.js
+++ b/test/unit/permission-ui/transition/TransitionEvents.test.js
@@ -63,21 +63,6 @@ describe('permission.ui', function () {
         });
       });
 
-      describe('method: broadcastStateChangeSuccessEvent', function () {
-        it('should broadcast "$stateChangeSuccess" event', function () {
-          // GIVEN
-          spyOn($rootScope, '$broadcast');
-
-          // WHEN
-          PermTransitionEvents.broadcastStateChangeSuccessEvent();
-
-          // THEN
-          expect($rootScope.$broadcast).toHaveBeenCalledWith('$stateChangeSuccess',
-            jasmine.any(Object), jasmine.any(Object), jasmine.any(Object), jasmine.any(Object)
-          );
-        });
-      });
-
       describe('method: areEventsDefaultPrevented', function () {
         it('should check if none of events prevents authorization', function () {
           // GIVEN


### PR DESCRIPTION
This is a pretty drastic change but I think its backwards compatible. Instead of hooking into the UI-Router flow via events, we are decorating their public transitionTo function. That way, we do not have any other extraneous side-effects including but not limited to: 
* Duplicate $stateChangeStart events
* The promise from $state.go/reload/transitionTo always being cancelled and a new one being made
* Preserved transitions options for location & others. 

I'd love to have a conversation regarding this change or something that may fix the above issues.