### PR TITLE
Checking for redirectTo definition

### DIFF
--- a/src/permission/authorization/PermissionMap.js
+++ b/src/permission/authorization/PermissionMap.js
@@ -46,13 +46,13 @@ function PermPermissionMap($q, $log, $injector, PermTransitionProperties, PermRo
    * @return {Promise}
    */
   PermissionMap.prototype.resolveRedirectState = function (rejectedPermissionName) {
-
-    var redirectState = this.redirectTo[rejectedPermissionName] || this.redirectTo['default'];
-
+    
     // If redirectTo definition is not found stay where you are
-    if (!angular.isDefined(redirectState)) {
+    if (!angular.isDefined(this.redirectTo)) {
       return $q.reject();
     }
+
+    var redirectState = this.redirectTo[rejectedPermissionName] || this.redirectTo['default'];
 
     return resolveRedirectState(redirectState, rejectedPermissionName);
   };


### PR DESCRIPTION
If we don't have a `redirectTo` property for `permissions` object in state definition, the following error occurs:
```
TypeError: Cannot read property 'ROLE_GUEST' of undefined
    at StatePermissionMap.PermPermissionMap.PermissionMap.resolveRedirectState (angular-permission.js:912)
    at handleUnauthorizedState (angular-permission-ui.js:158)
...
```
So I changed the order and the way of checking for `redirectTo` definition. Every thing is fine! ;)