### PR TITLE
Update dependency to ui-router

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "peerDependencies": {
     "angular-route": ">=1.4.8",
-    "angular-ui-router": "*"
+    "@uirouter/angularjs": "*"
   },
   "devDependencies": {
     "grunt": "^1.0.0",


### PR DESCRIPTION
Because of change package name in ui-router.
Old name causes warning on npm:
`npm WARN angular-permission@5.3.2 requires a peer of angular-ui-router@* but none was installed.`