### PR TITLE
Fix: A parent state's "except" permission that is met will override the child "except" permission that is not met

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ When creating an issue please include:
 
 Want to submit a Pull Request?
 ============================
-1. Create a branch from the `ng1`/`ng2` branch accordingly to used angular version
+1. Create a branch from the `development` branch
 2. Implement your new feature
-3. Submit a pull request to be merged in the `ng1`/`ng2` branch
+3. Submit a pull request to be merged in the `development` branch
 

--- a/test/unit/permission-ui/authorization/StateAuthorization.test.js
+++ b/test/unit/permission-ui/authorization/StateAuthorization.test.js
@@ -32,6 +32,14 @@ describe('permission.ui', function () {
           return false;
         });
 
+        PermPermissionStore.definePermission('editTopic', function () {
+          return false;
+        });
+
+        PermPermissionStore.definePermission('deleteUser', function () {
+          return true;
+        });
+
         PermRoleStore.defineRole('USER', ['editPosts']);
         PermRoleStore.defineRole('ADMIN', ['editUsers']);
       });
@@ -43,7 +51,6 @@ describe('permission.ui', function () {
           state.$$permissionState.and.callFake(function () {
             return {path: [{data: {permissions: {except: ['editUsers']}}}]};
           });
-
 
           // WHEN
           var map = new PermStatePermissionMap(state);
@@ -117,6 +124,102 @@ describe('permission.ui', function () {
           expect(authorizationResult).toBePromise();
           expect(authorizationResult).toBeRejectedWith('editPosts', jasmine.any(Object));
         });
+
+        it('should return resolved promise when a parent and a child state\'s "except" permissions are met', function () {
+          // GIVEN
+          var state = jasmine.createSpyObj('state', ['$$permissionState']);
+          state.$$permissionState.and.callFake(function () {
+            return {path: [
+              {data: {permissions: {except: ['editUsers']}}},
+              {data: {permissions: {except: ['editTopic']}}}
+            ]};
+          });
+
+          // WHEN
+          var map = new PermStatePermissionMap(state);
+          var authorizationResult = PermStateAuthorization.authorizeByPermissionMap(map);
+
+          // THEN
+          expect(authorizationResult).toBePromise();
+          expect(authorizationResult).toBeResolved();
+        });
+
+        it('should return rejected promise when a parent state\'s "except" permissions are not met', function () {
+          // GIVEN
+          var state = jasmine.createSpyObj('state', ['$$permissionState']);
+          state.$$permissionState.and.callFake(function () {
+            return {path: [
+              {data: {permissions: {except: ['editPosts', 'editUsers']}}},
+              {data: {permissions: {}}}
+            ]};
+          });
+
+          // WHEN
+          var map = new PermStatePermissionMap(state);
+          var authorizationResult = PermStateAuthorization.authorizeByPermissionMap(map);
+
+          // THEN
+          expect(authorizationResult).toBePromise();
+          expect(authorizationResult).toBeRejectedWith('editPosts', jasmine.any(Object));
+        });
+
+        it('should return rejected promise when a parent state\'s "except" permissions are met and child state\'s "except" permissions are not met', function () {
+          // GIVEN
+          var state = jasmine.createSpyObj('state', ['$$permissionState']);
+          state.$$permissionState.and.callFake(function () {
+            return {path: [
+              {data: {permissions: {except: ['editUsers']}}},
+              {data: {permissions: {except: ['editPosts']}}}
+            ]};
+          });
+
+          // WHEN
+          var map = new PermStatePermissionMap(state);
+          var authorizationResult = PermStateAuthorization.authorizeByPermissionMap(map);
+
+          // THEN
+          expect(authorizationResult).toBePromise();
+          expect(authorizationResult).toBeRejectedWith('editPosts', jasmine.any(Object));
+        });
+
+        it('should return rejected promise when a parent state\'s "except" permissions are not met and child state\'s "except" permissions are met', function () {
+          // GIVEN
+          var state = jasmine.createSpyObj('state', ['$$permissionState']);
+          state.$$permissionState.and.callFake(function () {
+            return {path: [
+              {data: {permissions: {except: ['editPosts']}}},
+              {data: {permissions: {except: ['editUsers']}}}
+            ]};
+          });
+
+          // WHEN
+          var map = new PermStatePermissionMap(state);
+          var authorizationResult = PermStateAuthorization.authorizeByPermissionMap(map);
+
+          // THEN
+          expect(authorizationResult).toBePromise();
+          expect(authorizationResult).toBeRejectedWith('editPosts', jasmine.any(Object));
+        });
+
+        it('should return rejected promise when a parent state\'s "except" permissions are not met and child state\'s "except" permissions are not met', function () {
+          // GIVEN
+          var state = jasmine.createSpyObj('state', ['$$permissionState']);
+          state.$$permissionState.and.callFake(function () {
+            return {path: [
+              {data: {permissions: {except: ['editPosts']}}},
+              {data: {permissions: {except: ['deleteUser']}}}
+            ]};
+          });
+
+          // WHEN
+          var map = new PermStatePermissionMap(state);
+          var authorizationResult = PermStateAuthorization.authorizeByPermissionMap(map);
+
+          // THEN
+          expect(authorizationResult).toBePromise();
+          expect(authorizationResult).toBeRejectedWith('editPosts', jasmine.any(Object));
+        });
+
       });
     });
   });


### PR DESCRIPTION
This means a user can access a State he shouldn't have permission to. Vice versa also applies.

I believe this fixes intended functionality (See last paragraph of https://github.com/Narzerus/angular-permission/wiki/Usage-in-ui-router-states#state-permission-inheritance)

See this [Codepen](https://codepen.io/nikokin/pen/eyrMOE) showing the bug in action. Clicking "Weasels BB" should redirect to "Weasels AA", because of the except definition, but doesn't. If you comment out the 'weasels' parent state (rootState), then the redirect works.

I added unit tests that fail without my change to "resolveExceptStatePermissionMap()". See the test in StateAuthorization.test.js: "should return rejected promise when a parent state\'s "except" permissions are met and child state\'s "except" permissions are not met".