### PR TITLE
fix: Keep transitionOptions location intact if truthy

### DIFF
--- a/src/permission-ui/permission-ui.js
+++ b/src/permission-ui/permission-ui.js
@@ -158,7 +158,7 @@ function run($injector, $rootScope, $state, PermTransitionProperties, PermTransi
       PermTransitionEvents.broadcastPermissionAcceptedEvent();
 
       // Overwrite notify option to broadcast it later
-      var transitionOptions = angular.extend({}, PermTransitionProperties.options, {notify: false, location: true});
+      var transitionOptions = angular.extend({}, PermTransitionProperties.options, {notify: false, location: PermTransitionProperties.options.location ? PermTransitionProperties.options.location : true});
 
       $state
         .go(PermTransitionProperties.toState.name, PermTransitionProperties.toParams, transitionOptions)


### PR DESCRIPTION
Hi guys,

Just found some issue where the `transitionOptions`.`location` = `replace` not being kept between all transitions which can lead into some trouble from `ui-router` location feature.

The idea is to keep the `replace` while specified and `true` otherwise.

Feel free to comment 👍